### PR TITLE
Use fuzzing to check invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-
       - run: npm install
-
       - run: npm test
-
+      - uses: actions/cache@v3
+        with:
+          path: fuzzing/corpus
+          key: fuzzing
+      - run: npm run fuzz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.15
       - run: npm install
       - run: npm test
       - uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 cache
 artifacts
 deployment-localhost.json
+crytic-export

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,10 @@ To run the tests, execute the following commands:
     npm install
     npm test
 
+You can also run fuzzing tests (using [Echidna][echidna]) on the contracts:
+
+    npm run fuzz
+
 To start a local Ethereum node with the contracts deployed, execute:
 
     npm start
@@ -132,3 +136,4 @@ To Do
 
   * Analysis and optimization of gas usage
 
+[echidna]: https://github.com/crytic/echidna

--- a/contracts/FuzzMarketplace.sol
+++ b/contracts/FuzzMarketplace.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./TestToken.sol";
+import "./Marketplace.sol";
+
+contract FuzzMarketplace is Marketplace {
+  constructor()
+    Marketplace(
+      new TestToken(),
+      MarketplaceConfig(CollateralConfig(10, 5, 3, 10), ProofConfig(10, 5, 64))
+    )
+  // solhint-disable-next-line no-empty-blocks
+  {
+
+  }
+
+  // Properties to be tested through fuzzing
+
+  MarketplaceTotals private _lastSeenTotals;
+
+  function neverDecreaseTotals() public {
+    assert(_marketplaceTotals.received >= _lastSeenTotals.received);
+    assert(_marketplaceTotals.sent >= _lastSeenTotals.sent);
+    _lastSeenTotals = _marketplaceTotals;
+  }
+
+  function neverLoseFunds() public view {
+    uint256 total = _marketplaceTotals.received - _marketplaceTotals.sent;
+    assert(token.balanceOf(address(this)) >= total);
+  }
+}

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -203,7 +203,7 @@ contract Marketplace is Proofs, StateRetrieval {
       slot.currentCollateral;
     _marketplaceTotals.sent += amount;
     slot.state = SlotState.Paid;
-    require(token.transfer(slot.host, amount), "Payment failed");
+    assert(token.transfer(slot.host, amount));
   }
 
   /// @notice Withdraws storage request funds back to the client that deposited them.
@@ -228,7 +228,7 @@ contract Marketplace is Proofs, StateRetrieval {
     // deducted from the price.
     uint256 amount = request.price();
     _marketplaceTotals.sent += amount;
-    require(token.transfer(msg.sender, amount), "Withdraw failed");
+    assert(token.transfer(msg.sender, amount));
   }
 
   function getActiveSlot(

--- a/contracts/Proofs.sol
+++ b/contracts/Proofs.sol
@@ -25,7 +25,7 @@ abstract contract Proofs is Periods {
     return _missed[slotId];
   }
 
-  function resetMissingProofs(SlotId slotId) internal {
+  function _resetMissingProofs(SlotId slotId) internal {
     _missed[slotId] = 0;
   }
 

--- a/fuzzing/corpus/.gitignore
+++ b/fuzzing/corpus/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.keep

--- a/fuzzing/echidna.yaml
+++ b/fuzzing/echidna.yaml
@@ -1,0 +1,6 @@
+# configure Echidna fuzzing tests
+
+testMode: "assertion"       # check that solidity asserts are never triggered
+multi-abi: true             # allow calls to e.g. TestToken in test scenarios
+corpusDir: "fuzzing/corpus" # collect coverage maximizing corpus in this dir
+format: "text"              # disable interactive ui

--- a/fuzzing/echidna.yaml
+++ b/fuzzing/echidna.yaml
@@ -2,5 +2,4 @@
 
 testMode: "assertion"       # check that solidity asserts are never triggered
 multi-abi: true             # allow calls to e.g. TestToken in test scenarios
-corpusDir: "fuzzing/corpus" # collect coverage maximizing corpus in this dir
 format: "text"              # disable interactive ui

--- a/fuzzing/echidna.yaml
+++ b/fuzzing/echidna.yaml
@@ -3,3 +3,9 @@
 testMode: "assertion"       # check that solidity asserts are never triggered
 allContracts: true          # allow calls to e.g. TestToken in test scenarios
 format: "text"              # disable interactive ui
+
+# For a longer test run, consider these options:
+# timeout: 3600               # limit test run to one hour
+# testLimit: 100000000000     # do not limit the amount of test sequences
+# stopOnFail: true            # stop on first failure
+# workers: 8                  # use more cpu cores

--- a/fuzzing/echidna.yaml
+++ b/fuzzing/echidna.yaml
@@ -1,5 +1,5 @@
 # configure Echidna fuzzing tests
 
 testMode: "assertion"       # check that solidity asserts are never triggered
-multi-abi: true             # allow calls to e.g. TestToken in test scenarios
+allContracts: true          # allow calls to e.g. TestToken in test scenarios
 format: "text"              # disable interactive ui

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+echidna-test . --contract FuzzMarketplace --config fuzzing/echidna.yaml

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -3,9 +3,9 @@ set -e
 
 root=$(cd $(dirname "$0")/.. && pwd)
 
-if command -v echidna-test; then
+if command -v echidna; then
   fuzz () {
-    echidna-test ${root} \
+    echidna ${root} \
       --config ${root}/fuzzing/echidna.yaml \
       --corpus-dir ${root}/fuzzing/corpus \
       --crytic-args --ignore-compile \
@@ -17,7 +17,7 @@ else
       --rm \
       -v ${root}:/src ghcr.io/crytic/echidna/echidna \
       bash -c \
-        "cd /src && echidna-test . \
+        "cd /src && echidna . \
           --config fuzzing/echidna.yaml \
           --corpus-dir fuzzing/corpus \
           --crytic-args --ignore-compile \

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -1,3 +1,23 @@
 #!/bin/bash
 set -e
-echidna-test . --contract FuzzMarketplace --config fuzzing/echidna.yaml
+
+if command -v echidna-test; then
+  fuzz () {
+    echidna-test . \
+      --config fuzzing/echidna.yaml \
+      --contract $1
+  }
+else
+  fuzz () {
+    docker run \
+      --rm \
+      -v `pwd`:/src ghcr.io/crytic/echidna/echidna \
+      bash -c \
+        "cd /src && echidna-test . \
+          --config fuzzing/echidna.yaml \
+          --crytic-args --ignore-compile \
+          --contract $1"
+  }
+fi
+
+fuzz FuzzMarketplace

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 root=$(cd $(dirname "$0")/.. && pwd)

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 set -e
 
+root=$(cd $(dirname "$0")/.. && pwd)
+
 if command -v echidna-test; then
   fuzz () {
-    echidna-test . \
-      --config fuzzing/echidna.yaml \
+    echidna-test ${root} \
+      --config ${root}/fuzzing/echidna.yaml \
+      --corpus-dir ${root}/fuzzing/corpus \
       --contract $1
   }
 else
   fuzz () {
     docker run \
       --rm \
-      -v `pwd`:/src ghcr.io/crytic/echidna/echidna \
+      -v ${root}:/src ghcr.io/crytic/echidna/echidna \
       bash -c \
         "cd /src && echidna-test . \
           --config fuzzing/echidna.yaml \
+          --corpus-dir fuzzing/corpus \
           --crytic-args --ignore-compile \
           --contract $1"
   }

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -8,6 +8,7 @@ if command -v echidna-test; then
     echidna-test ${root} \
       --config ${root}/fuzzing/echidna.yaml \
       --corpus-dir ${root}/fuzzing/corpus \
+      --crytic-args --ignore-compile \
       --contract $1
   }
 else

--- a/fuzzing/fuzz.sh
+++ b/fuzzing/fuzz.sh
@@ -2,6 +2,7 @@
 set -e
 
 root=$(cd $(dirname "$0")/.. && pwd)
+arch=$(arch)
 
 if command -v echidna; then
   fuzz () {
@@ -11,7 +12,7 @@ if command -v echidna; then
       --crytic-args --ignore-compile \
       --contract $1
   }
-else
+elif [ "${arch}" = "x86_64" ]; then
   fuzz () {
     docker run \
       --rm \
@@ -23,6 +24,10 @@ else
           --crytic-args --ignore-compile \
           --contract $1"
   }
+else
+  echo "Error: echidna not found, and the docker image does not support ${arch}"
+  echo "Please install echidna: https://github.com/crytic/echidna#installation"
+  exit 1
 fi
 
 fuzz FuzzMarketplace

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run lint && hardhat test",
-    "fuzz": "fuzzing/fuzz.sh",
+    "fuzz": "hardhat compile && fuzzing/fuzz.sh",
     "start": "hardhat node --export deployment-localhost.json",
     "compile": "hardhat compile",
     "format": "prettier --write contracts/**/*.sol test/**/*.js",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run lint && hardhat test",
+    "fuzz": "fuzzing/fuzz.sh",
     "start": "hardhat node --export deployment-localhost.json",
     "compile": "hardhat compile",
     "format": "prettier --write contracts/**/*.sol test/**/*.js",

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -29,7 +29,7 @@ const {
   currentTime,
 } = require("./evm")
 
-describe('Marketplace constructor', function () {
+describe("Marketplace constructor", function () {
   let Marketplace, token, config
 
   beforeEach(async function () {
@@ -51,21 +51,21 @@ describe('Marketplace constructor', function () {
     it(`should reject for ${property} overflowing percentage values`, async () => {
       config.collateral[property] = 101
 
-      await expect(Marketplace.deploy(token.address, config)).to.be.revertedWith(
-        "Must be less than 100"
-      )
+      await expect(
+        Marketplace.deploy(token.address, config)
+      ).to.be.revertedWith("Must be less than 100")
     })
   }
 
-  testPercentageOverflow('repairRewardPercentage')
-  testPercentageOverflow('slashPercentage')
+  testPercentageOverflow("repairRewardPercentage")
+  testPercentageOverflow("slashPercentage")
 
-  it('should reject when total slash percentage exceeds 100%', async () => {
+  it("should reject when total slash percentage exceeds 100%", async () => {
     config.collateral.slashPercentage = 1
     config.collateral.maxNumberOfSlashes = 101
 
     await expect(Marketplace.deploy(token.address, config)).to.be.revertedWith(
-      "Total slash percentage must be less then 100"
+      "Maximum slashing exceeds 100%"
     )
   })
 })
@@ -250,7 +250,10 @@ describe("Marketplace", function () {
 
     it("fails when all slots are already filled", async function () {
       const lastSlot = request.ask.slots - 1
-      await token.approve(marketplace.address, request.ask.collateral * lastSlot)
+      await token.approve(
+        marketplace.address,
+        request.ask.collateral * lastSlot
+      )
       await token.approve(marketplace.address, price(request) * lastSlot)
       for (let i = 0; i <= lastSlot; i++) {
         await marketplace.fillSlot(slot.request, i, proof)
@@ -278,11 +281,11 @@ describe("Marketplace", function () {
     })
 
     it("collects only requested collateral and not more", async function () {
-      await token.approve(marketplace.address, request.ask.collateral*2)
+      await token.approve(marketplace.address, request.ask.collateral * 2)
       const startBalanace = await token.balanceOf(host.address)
       await marketplace.fillSlot(slot.request, slot.index, proof)
       const endBalance = await token.balanceOf(host.address)
-      expect(startBalanace-endBalance).to.eq(request.ask.collateral)
+      expect(startBalanace - endBalance).to.eq(request.ask.collateral)
     })
   })
 
@@ -394,7 +397,9 @@ describe("Marketplace", function () {
       const startBalance = await token.balanceOf(host.address)
       await marketplace.freeSlot(slotId(slot))
       const endBalance = await token.balanceOf(host.address)
-      expect(endBalance - startBalance).to.equal(pricePerSlot(request) + request.ask.collateral)
+      expect(endBalance - startBalance).to.equal(
+        pricePerSlot(request) + request.ask.collateral
+      )
     })
 
     it("pays the host when contract was cancelled", async function () {
@@ -443,7 +448,10 @@ describe("Marketplace", function () {
 
     it("emits event when all slots are filled", async function () {
       const lastSlot = request.ask.slots - 1
-      await token.approve(marketplace.address, request.ask.collateral * lastSlot)
+      await token.approve(
+        marketplace.address,
+        request.ask.collateral * lastSlot
+      )
       for (let i = 0; i < lastSlot; i++) {
         await marketplace.fillSlot(slot.request, i, proof)
       }
@@ -465,7 +473,10 @@ describe("Marketplace", function () {
     })
     it("fails when all slots are already filled", async function () {
       const lastSlot = request.ask.slots - 1
-      await token.approve(marketplace.address, request.ask.collateral * (lastSlot + 1))
+      await token.approve(
+        marketplace.address,
+        request.ask.collateral * (lastSlot + 1)
+      )
       for (let i = 0; i <= lastSlot; i++) {
         await marketplace.fillSlot(slot.request, i, proof)
       }
@@ -501,7 +512,10 @@ describe("Marketplace", function () {
     it("rejects withdraw when in wrong state", async function () {
       // fill all slots, should change state to RequestState.Started
       const lastSlot = request.ask.slots - 1
-      await token.approve(marketplace.address, request.ask.collateral * (lastSlot + 1))
+      await token.approve(
+        marketplace.address,
+        request.ask.collateral * (lastSlot + 1)
+      )
       for (let i = 0; i <= lastSlot; i++) {
         await marketplace.fillSlot(slot.request, i, proof)
       }
@@ -569,7 +583,10 @@ describe("Marketplace", function () {
     })
 
     it("does not change to 'Failed' before it is started", async function () {
-      await token.approve(marketplace.address, request.ask.collateral * (request.ask.maxSlotLoss + 1))
+      await token.approve(
+        marketplace.address,
+        request.ask.collateral * (request.ask.maxSlotLoss + 1)
+      )
       for (let i = 0; i <= request.ask.maxSlotLoss; i++) {
         await marketplace.fillSlot(slot.request, i, proof)
       }
@@ -701,7 +718,7 @@ describe("Marketplace", function () {
           (await marketplace.isProofRequired(id)) &&
           (await marketplace.getPointer(id)) < 250
         )
-        ) {
+      ) {
         await advanceTime(period)
       }
     }
@@ -774,7 +791,7 @@ describe("Marketplace", function () {
           (await marketplace.isProofRequired(id)) &&
           (await marketplace.getPointer(id)) < 250
         )
-        ) {
+      ) {
         await advanceTime(period)
       }
     }
@@ -799,42 +816,67 @@ describe("Marketplace", function () {
           await advanceTime(period)
           await marketplace.markProofAsMissing(id, missedPeriod)
         }
-        const expectedBalance = (request.ask.collateral * (100 - slashPercentage)) / 100
+        const expectedBalance =
+          (request.ask.collateral * (100 - slashPercentage)) / 100
 
-        expect(BigNumber.from(expectedBalance).eq(await marketplace.getSlotCollateral(id)))
+        expect(
+          BigNumber.from(expectedBalance).eq(
+            await marketplace.getSlotCollateral(id)
+          )
+        )
       })
     })
 
     it("frees slot when collateral slashed below minimum threshold", async function () {
-      const minimum = request.ask.collateral - (request.ask.collateral*config.collateral.maxNumberOfSlashes*config.collateral.slashPercentage)/100
+      const minimum =
+        request.ask.collateral -
+        (request.ask.collateral *
+          config.collateral.maxNumberOfSlashes *
+          config.collateral.slashPercentage) /
+          100
       await waitUntilStarted(marketplace, request, proof, token)
       while ((await marketplace.slotState(slotId(slot))) === SlotState.Filled) {
-        expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.gt(minimum)
+        expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.gt(
+          minimum
+        )
         await waitUntilProofIsRequired(slotId(slot))
         const missedPeriod = periodOf(await currentTime())
         await advanceTime(period)
         await marketplace.markProofAsMissing(slotId(slot), missedPeriod)
       }
       expect(await marketplace.slotState(slotId(slot))).to.equal(SlotState.Free)
-      expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.lte(minimum)
+      expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.lte(
+        minimum
+      )
     })
 
     it("free slot when minimum reached and resets missed proof counter", async function () {
-      const minimum = request.ask.collateral - (request.ask.collateral*config.collateral.maxNumberOfSlashes*config.collateral.slashPercentage)/100
+      const minimum =
+        request.ask.collateral -
+        (request.ask.collateral *
+          config.collateral.maxNumberOfSlashes *
+          config.collateral.slashPercentage) /
+          100
       await waitUntilStarted(marketplace, request, proof, token)
       let missedProofs = 0
       while ((await marketplace.slotState(slotId(slot))) === SlotState.Filled) {
-        expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.gt(minimum)
+        expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.gt(
+          minimum
+        )
         await waitUntilProofIsRequired(slotId(slot))
         const missedPeriod = periodOf(await currentTime())
         await advanceTime(period)
-        expect(await marketplace.missingProofs(slotId(slot))).to.equal(missedProofs)
+        expect(await marketplace.missingProofs(slotId(slot))).to.equal(
+          missedProofs
+        )
         await marketplace.markProofAsMissing(slotId(slot), missedPeriod)
         missedProofs += 1
       }
       expect(await marketplace.slotState(slotId(slot))).to.equal(SlotState.Free)
       expect(await marketplace.missingProofs(slotId(slot))).to.equal(0)
-      expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.lte(minimum)
+      expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.lte(
+        minimum
+      )
     })
   })
 


### PR DESCRIPTION
Simplifies the contract code by moving the invariant checks to separate files.
Uses [echidna](https://github.com/crytic/echidna) to perform the fuzzing.