### PR TITLE
Add Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '18'
-    - run: npm install
-    - run: npm test
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: npm install
+
+      - run: npm test
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,155 @@
+name: Docker
+
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v*.*.*"
+    paths-ignore:
+      - '**/*.md'
+      - '.gitignore'
+      - '.github/**'
+      - '!.github/workflows/docker.yml'
+  workflow_dispatch:
+
+
+env:
+  DOCKER_FILE: docker/Dockerfile
+  DOCKER_REPO: codexstorage/codex-contracts-eth
+
+
+jobs:
+  # Build platform specific image
+  build:
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+        include:
+          - target:
+              os: linux
+              arch: amd64
+            builder: ubuntu-22.04
+          - target:
+              os: linux
+              arch: arm64
+            builder: buildjet-4vcpu-ubuntu-2204-arm
+
+    name: Build ${{ matrix.target.os }}/${{ matrix.target.arch }}
+    runs-on: ${{ matrix.builder }}
+    outputs:
+      tags-linux-amd64: ${{ steps.tags.outputs.tags-linux-amd64 }}
+      tags-linux-arm64: ${{ steps.tags.outputs.tags-linux-arm64 }}
+    env:
+      PLATFORM: ${{ format('{0}/{1}', 'linux', matrix.target.arch) }}
+      SUFFIX: ${{ format('{0}-{1}', 'linux', matrix.target.arch) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Docker - Meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_REPO }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}},suffix=-${{ env.SUFFIX }}
+            type=sha,suffix=-${{ env.SUFFIX }},enable=${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Docker - Set tags output
+        if: github.event_name != 'pull_request'
+        id: tags
+        run: |
+          if [[ '${{ matrix.target.os }}' == 'linux' && '${{ matrix.target.arch }}' == 'amd64' ]]; then
+            echo "tags-linux-amd64=${{ steps.meta.outputs.tags }}" >> "$GITHUB_OUTPUT"
+          elif [[ '${{ matrix.target.os }}' == 'linux' && '${{ matrix.target.arch }}' == 'arm64' ]]; then
+            echo "tags-linux-arm64=${{ steps.meta.outputs.tags }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Docker - Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker - Build and export to Docker
+        id: build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.PLATFORM }}
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Docker - Minify image
+        uses: kitabisa/docker-slim-action@v1
+        id: slim
+        env:
+          DSLIM_HTTP_PROBE: false
+        with:
+          target: ${{ steps.meta.outputs.tags }}
+          overwrite: true
+
+      - name: Docker - Show slim report
+        run: echo "${REPORT}" | jq -r
+        env:
+          REPORT: ${{ steps.slim.outputs.report }}
+
+      - name: Docker - Push to Docker registry
+        if: github.event_name != 'pull_request'
+        id: push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ env.DOCKER_FILE }}
+          platforms: ${{ env.PLATFORM }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  # Publish single image
+  publish:
+    name: Push single image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Docker - Meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.DOCKER_REPO }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,enable=${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Docker - Set tags
+        run: |
+          # Transform multi-line tags in to the comma-seperated
+          TAGS=$(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ',' | awk '{gsub(/,$/,"");}1')
+          echo "TAGS=${TAGS}" >>$GITHUB_ENV
+
+      - name: Docker - Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker - Create and push manifest images
+        uses: Noelware/docker-manifest-action@master
+        with:
+          inputs: ${{ env.TAGS }}
+          images: ${{ needs.build.outputs.tags-linux-amd64 }},${{ needs.build.outputs.tags-linux-arm64 }}
+          push: true
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+# Variables
+ARG BUILDER=node:18.15.0-slim
+ARG IMAGE=${BUILDER}
+ARG APP_USER=root
+ARG APP_HOME=/hardhat
+
+
+# Build
+FROM ${BUILDER} AS builder
+
+ARG APP_USER
+ARG APP_HOME
+
+# Install fail on arm64 without additional packages
+RUN if [ $(uname -m) = "aarch64" ] ; then \
+      if [ $(awk -F '=' '/^ID/ {print $2}' /etc/os-release) = "alpine" ] ; then \
+        apk add --update --no-cache python3 python3 make g++ ; \
+      else \
+        apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/* ; \
+      fi \
+    fi
+
+WORKDIR ${APP_HOME}
+COPY --chown=${APP_USER}:${APP_USER} . .
+
+RUN npm install
+
+
+# Create
+FROM ${IMAGE}
+
+ARG APP_USER
+ARG APP_HOME
+
+WORKDIR ${APP_HOME}
+COPY --chown=${APP_USER}:${APP_USER} --from=builder ${APP_HOME} .
+
+EXPOSE 8545
+
+ENTRYPOINT ["npm", "start"]
+


### PR DESCRIPTION
This is a follow up of the https://github.com/codex-storage/nim-codex/issues/412 and we added automated Docker builds.

Some information about performed experiments, because resulted image size is not so small

| Stage            | Image          | Build, m | Push, m | Total, m | Size, MB   |
| ---------------- | -------------- | -------- | ------- | -------- | ---------- |
| **Single-stage** | `slim amd64`   | 02:08    | 00:08   | 03:14    | 250.99     |
|                  | `slim arm64`   | 02:24    |         |          | 345.89     |
|                  | `alpine amd64` | 02:12    | 00:08   | 02:43    | 225.26     |
|                  | `alpine arm64` | 01:57    |         |          | 320.52     |
| **Milti-stage**  | `slim amd64`   | 01:56    | 00:07   | 02:44    | **162.20** |
|                  | `slim arm64`   | 02:19    |         |          | 162.43     |
|                  | `alpine amd64` | 02:15    | 00:09   | 02:44    | **136.49** |
|                  | `alpine arm64` | 01:53    |         |          | 136.99     |

We chose the `slim` one, as a smallest officially supported - [Choosing the best Node.js Docker image](https://snyk.io/blog/choosing-the-best-node-js-docker-image/).  Also [multi-stage builds](https://docs.docker.com/build/building/multi-stage/) provides a smaller size.

Images are published under Codex organization repository - [codexstorage/codex-contracts-eth](https://hub.docker.com/r/codexstorage/codex-contracts-eth/tags)

Now, we use same approach as for nim-codex
```
# On commit
sha-0a20b12
sha-0a20b12-linux-arm64
sha-0a20b12-linux-amd64

# On tag
latest
0.0.1
0.0.1-linux-arm64
0.0.1-linux-amd64
```

**Usage**
```bash
# Run
docker run \
  --rm \
  --name codex-contracts-eth \
  codexstorage/codex-contracts-eth:sha-0a20b12

# Publish port
docker run \
  --rm \
  --publish 8545:8545 \
  --name codex-contracts-eth \
  codexstorage/codex-contracts-eth:sha-0a20b12

# Check enpoint
curl localhost:8545 \
  --request POST \
  --silent \
  --data '{"jsonrpc": "2.0", "method": "eth_getBlockByNumber", "params":["latest", false], "id": 1}' | \
  jq -r
```