### PR TITLE
Add Docker builds for Dist-Tests

### DIFF
--- a/.github/workflows/docker-dist-tests.yml
+++ b/.github/workflows/docker-dist-tests.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Docker Dist-Tests
 
 
 on:
@@ -11,15 +11,15 @@ on:
       - '**/*.md'
       - '.gitignore'
       - 'docker/**'
-      - '!docker/Dockerfile'
+      - '!docker/delpoy.*'
       - '.github/**'
-      - '!.github/workflows/docker.yml'
+      - '!.github/workflows/docker-dist-tests.yml'
   workflow_dispatch:
 
 
 env:
-  DOCKER_FILE: docker/Dockerfile
-  DOCKER_REPO: codexstorage/codex-contracts-eth
+  DOCKER_FILE: docker/deploy.Dockerfile
+  DOCKER_REPO: codexstorage/dist-tests-codex-contracts-eth
 
 
 jobs:

--- a/docker/deploy.Dockerfile
+++ b/docker/deploy.Dockerfile
@@ -1,5 +1,40 @@
-FROM node:18.16.0-alpine3.17
-WORKDIR /usr/app
-COPY . .
-RUN ["npm", "install"]
+# Variables
+ARG BUILDER=node:18.16.0-alpine3.17
+ARG IMAGE=${BUILDER}
+ARG APP_USER=root
+ARG APP_HOME=/hardhat
+
+
+# Build
+FROM ${BUILDER} AS builder
+
+ARG APP_USER
+ARG APP_HOME
+
+# Install fail on arm64 without additional packages
+RUN if [ $(uname -m) = "aarch64" ] ; then \
+      if [ $(awk -F '=' '/^ID/ {print $2}' /etc/os-release) = "alpine" ] ; then \
+        apk add --update --no-cache python3 python3 make g++ ; \
+      else \
+        apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/* ; \
+      fi \
+    fi
+
+WORKDIR ${APP_HOME}
+COPY --chown=${APP_USER}:${APP_USER} . .
+
+RUN npm install
+
+
+# Create
+FROM ${IMAGE}
+
+ARG APP_USER
+ARG APP_HOME
+
+WORKDIR ${APP_HOME}
+COPY --chown=${APP_USER}:${APP_USER} --from=builder ${APP_HOME} .
+
+EXPOSE 8545
+
 CMD ["sh", "docker/deploy.sh"]


### PR DESCRIPTION
This PR adds Docker builds which are [required by Dist-Tests](https://github.com/codex-storage/cs-codex-dist-tests/issues/34). It is done besides recently added [Add Docker builds #56](56) and we will store images in different DockerHub repositories
 - [codexstorage/codex-contracts-eth](https://hub.docker.com/r/codexstorage/codex-contracts-eth/tags)
 - [codexstorage/dist-tests-codex-contracts-eth](https://hub.docker.com/r/codexstorage/dist-tests-codex-contracts-eth/tags)

These builds has slightly different behaviour and we probably would like how have both of them.

Also, it was required to update existing [docker/deploy.Dockerfile](https://github.com/codex-storage/codex-contracts-eth/blob/master/docker/deploy.Dockerfile) because
1. Builds on ARM failed without additional packages installation
2. We decreased resulting Docker image almost twice by [using Multi-stage builds](56)

