### PR TITLE
chore: Bump Node version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Variables
-ARG BUILDER=node:18.15.0-slim
+ARG BUILDER=node:18.17.0-slim
 ARG IMAGE=${BUILDER}
 ARG APP_USER=root
 ARG APP_HOME=/hardhat
@@ -14,7 +14,7 @@ ARG APP_HOME
 # Install fail on arm64 without additional packages
 RUN if [ $(uname -m) = "aarch64" ] ; then \
       if [ $(awk -F '=' '/^ID/ {print $2}' /etc/os-release) = "alpine" ] ; then \
-        apk add --update --no-cache python3 python3 make g++ ; \
+        apk add --update --no-cache python3 make g++ ; \
       else \
         apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/* ; \
       fi \
@@ -38,4 +38,3 @@ COPY --chown=${APP_USER}:${APP_USER} --from=builder ${APP_HOME} .
 EXPOSE 8545
 
 ENTRYPOINT ["npm", "start"]
-


### PR DESCRIPTION
We [recently updated Hardhat and Node](64) to the lates versions.

Because both dockerfiles uses same source code it make sense to update main Dockerfile to use same Node version.