### PR TITLE
Remove PoR parameters, add merkle root for storage proofs

### DIFF
--- a/contracts/Requests.sol
+++ b/contracts/Requests.sol
@@ -23,19 +23,8 @@ struct Ask {
 }
 
 struct Content {
-  string cid; // content id (if part of a larger set, the chunk cid)
-  Erasure erasure; // Erasure coding attributes
-  PoR por; // Proof of Retrievability parameters
-}
-
-struct Erasure {
-  uint64 totalChunks; // the total number of chunks in the larger data set
-}
-
-struct PoR {
-  bytes u; // parameters u_1..u_s
-  bytes publicKey; // public key
-  bytes name; // random name
+  string cid; // content id, used to download the dataset
+  bytes merkleRoot; // merkle root of the dataset, used to verify storage proofs
 }
 
 enum RequestState {

--- a/contracts/Requests.sol
+++ b/contracts/Requests.sol
@@ -24,7 +24,7 @@ struct Ask {
 
 struct Content {
   string cid; // content id, used to download the dataset
-  bytes merkleRoot; // merkle root of the dataset, used to verify storage proofs
+  bytes32 merkleRoot; // merkle root of the dataset, used to verify storage proofs
 }
 
 enum RequestState {

--- a/test/examples.js
+++ b/test/examples.js
@@ -32,14 +32,7 @@ const exampleRequest = async () => {
     },
     content: {
       cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",
-      erasure: {
-        totalChunks: 12,
-      },
-      por: {
-        u: Array.from(randomBytes(480)),
-        publicKey: Array.from(randomBytes(96)),
-        name: Array.from(randomBytes(512)),
-      },
+      merkleRoot: Array.from(randomBytes(32))
     },
     expiry: now + hours(1),
     nonce: hexlify(randomBytes(32)),

--- a/test/ids.js
+++ b/test/ids.js
@@ -3,9 +3,7 @@ const { keccak256, defaultAbiCoder } = ethers.utils
 
 function requestId(request) {
   const Ask = "tuple(int64, uint256, uint256, uint256, uint256, uint256, int64)"
-  const Erasure = "tuple(uint64)"
-  const PoR = "tuple(bytes, bytes, bytes)"
-  const Content = "tuple(string, " + Erasure + ", " + PoR + ")"
+  const Content = "tuple(string, bytes)"
   const Request =
     "tuple(address, " + Ask + ", " + Content + ", uint256, bytes32)"
   return keccak256(defaultAbiCoder.encode([Request], requestToArray(request)))
@@ -23,16 +21,8 @@ function askToArray(ask) {
   ]
 }
 
-function erasureToArray(erasure) {
-  return [erasure.totalChunks]
-}
-
-function porToArray(por) {
-  return [por.u, por.publicKey, por.name]
-}
-
 function contentToArray(content) {
-  return [content.cid, erasureToArray(content.erasure), porToArray(content.por)]
+  return [content.cid, content.merkleRoot]
 }
 
 function requestToArray(request) {

--- a/test/ids.js
+++ b/test/ids.js
@@ -3,7 +3,7 @@ const { keccak256, defaultAbiCoder } = ethers.utils
 
 function requestId(request) {
   const Ask = "tuple(int64, uint256, uint256, uint256, uint256, uint256, int64)"
-  const Content = "tuple(string, bytes)"
+  const Content = "tuple(string, bytes32)"
   const Request =
     "tuple(address, " + Ask + ", " + Content + ", uint256, bytes32)"
   return keccak256(defaultAbiCoder.encode([Request], requestToArray(request)))


### PR DESCRIPTION
Update Request to accomodate new proving scheme:
- Remove PoR parameters
- Remove total number of chunks
- Add merkle root of the dataset