### PR TITLE
Increase pointer by 67 blocks each time the period is increased

### DIFF
--- a/contracts/Proofs.sol
+++ b/contracts/Proofs.sol
@@ -36,10 +36,10 @@ abstract contract Proofs is Periods {
 
   function _getPointer(SlotId id, Period period) internal view returns (uint8) {
     uint256 blockNumber = block.number % 256;
-    // To ensure the pointer is not in downtime in subsequent periods, for each
-    // period increase, move the pointer 64 blocks. In this way, the pointer
-    // will be in downtime every fourth period.
-    uint256 periodNumber = Period.unwrap(period) * 64 % 256;
+    // To ensure the pointer does not remain in downtime for many consecutive
+    // periods, for each period increase, move the pointer 67 blocks. We've
+    // chosen a prime number to ensure that we don't get cycles.
+    uint256 periodNumber = (Period.unwrap(period) * 67) % 256;
     uint256 idOffset = uint256(SlotId.unwrap(id)) % 256;
     uint256 pointer = (blockNumber + periodNumber + idOffset) % 256;
     return uint8(pointer);

--- a/contracts/Proofs.sol
+++ b/contracts/Proofs.sol
@@ -36,7 +36,10 @@ abstract contract Proofs is Periods {
 
   function _getPointer(SlotId id, Period period) internal view returns (uint8) {
     uint256 blockNumber = block.number % 256;
-    uint256 periodNumber = Period.unwrap(period) % 256;
+    // To ensure the pointer is not in downtime in subsequent periods, for each
+    // period increase, move the pointer 64 blocks. In this way, the pointer
+    // will be in downtime every fourth period.
+    uint256 periodNumber = Period.unwrap(period) * 64 % 256;
     uint256 idOffset = uint256(SlotId.unwrap(id)) % 256;
     uint256 pointer = (blockNumber + periodNumber + idOffset) % 256;
     return uint8(pointer);


### PR DESCRIPTION
In order to prevent the pointer from being in downtime through many consecutive periods (up to 64 blocks, or just over 6 periods), the pointer is increased by 64 blocks each time the period is increased.

### Note
Based on https://github.com/codex-storage/codex-contracts-eth/pull/78