### PR TITLE
fix: check expiration is before request end

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -84,7 +84,9 @@ contract Marketplace is Proofs, StateRetrieval {
     require(_requests[id].client == address(0), "Request already exists");
 
     _requests[id] = request;
-    _requestContexts[id].endsAt = block.timestamp + request.ask.duration;
+    uint256 requestEnd = block.timestamp + request.ask.duration;
+    require(requestEnd > request.expiry, "Request end before expiry");
+    _requestContexts[id].endsAt = requestEnd;
 
     _addToMyRequests(request.client, id);
 

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -152,6 +152,14 @@ describe("Marketplace", function () {
       )
     })
 
+    it("rejects request when expiry is after request end", async function () {
+      request.expiry = await currentTime() + request.ask.duration + hours(1)
+      await token.approve(marketplace.address, price(request))
+      await expect(marketplace.requestStorage(request)).to.be.revertedWith(
+        "Request end before expiry"
+      )
+    })
+
     it("rejects resubmission of request", async function () {
       await token.approve(marketplace.address, price(request) * 2)
       await marketplace.requestStorage(request)


### PR DESCRIPTION
During some manual testing, I ran into a case when I accidentally specified the expiry to be farther than the request's end. This led to underflow errors due to the calculation of the `expiryFundsWithdraw` during the `fillSlot()` event. This is a fix that prevents this condition.

In the `nim-codex` follow-up PR, I will also add a check for this on the API level.