### PR TITLE
Dummy verifier

### DIFF
--- a/contracts/TestVerifier.sol
+++ b/contracts/TestVerifier.sol
@@ -4,20 +4,19 @@ pragma solidity 0.8.23;
 import "./Groth16.sol";
 
 contract TestVerifier is IGroth16Verifier {
-  bool private _proofsAreValid;
-
-  constructor() {
-    _proofsAreValid = true;
-  }
-
-  function setProofsAreValid(bool proofsAreValid) public {
-    _proofsAreValid = proofsAreValid;
-  }
-
   function verify(
-    Groth16Proof calldata,
+    Groth16Proof calldata proof,
     uint[] calldata
-  ) external view returns (bool) {
-    return _proofsAreValid;
+  ) external pure returns (bool) {
+    // accepts any proof, except the proof with all zero values
+    return
+      !(proof.a.x == 0 &&
+        proof.a.y == 0 &&
+        proof.b.x[0] == 0 &&
+        proof.b.x[1] == 0 &&
+        proof.b.y[0] == 0 &&
+        proof.b.y[1] == 0 &&
+        proof.c.x == 0 &&
+        proof.c.y == 0);
   }
 }

--- a/deploy/marketplace.js
+++ b/deploy/marketplace.js
@@ -1,9 +1,5 @@
 const { loadZkeyHash } = require("../verifier/verifier.js")
 
-// hardcoded addresses when deploying on local network
-const MARKETPLACE_REAL = "0x59b670e9fA9D0A427751Af201D676719a970857b"
-const MARKETPLACE_TEST = "0xfacadee9fA9D0A427751Af201D676719a9facade"
-
 // marketplace configuration
 const CONFIGURATION = {
   collateral: {
@@ -25,14 +21,8 @@ async function mine256blocks({ network, ethers }) {
   }
 }
 
-async function aliasContract(address, alias) {
-  if (address !== alias) {
-    await ethers.provider.send("hardhat_setCode", [alias, address])
-  }
-}
-
 // deploys a marketplace with a real Groth16 verifier
-async function deployMarketplace({ network, deployments, getNamedAccounts }) {
+async function deployMarketplace({ deployments, getNamedAccounts }) {
   const token = await deployments.get("TestToken")
   const verifier = await deployments.get("Groth16Verifier")
   const zkeyHash = loadZkeyHash(network.name)
@@ -40,9 +30,9 @@ async function deployMarketplace({ network, deployments, getNamedAccounts }) {
   const args = [configuration, token.address, verifier.address]
   const { deployer: from } = await getNamedAccounts()
   const marketplace = await deployments.deploy("Marketplace", { args, from })
-  if (network.tags.local) {
-    await aliasContract(marketplace.address, MARKETPLACE_REAL)
-  }
+  console.log("Deployed Marketplace with Groth16 Verifier at:")
+  console.log(marketplace.address)
+  console.log()
 }
 
 // deploys a marketplace with a testing verifier
@@ -59,7 +49,9 @@ async function deployTestMarketplace({
     const args = [configuration, token.address, verifier.address]
     const { deployer: from } = await getNamedAccounts()
     const marketplace = await deployments.deploy("Marketplace", { args, from })
-    await aliasContract(marketplace.address, MARKETPLACE_TEST)
+    console.log("Deployed Marketplace with Test Verifier at:")
+    console.log(marketplace.address)
+    console.log()
   }
 }
 

--- a/deploy/token.js
+++ b/deploy/token.js
@@ -13,6 +13,7 @@ module.exports = async ({ deployments, getNamedAccounts, getUnnamedAccounts, net
       const transaction = await token.mint(account, MINTED_TOKENS, { from: deployer })
       await transaction.wait()
     }
+    console.log()
   }
 }
 

--- a/deploy/verifier.js
+++ b/deploy/verifier.js
@@ -1,9 +1,24 @@
-const { loadVerificationKey } = require ("../verifier/verifier.js")
+const { loadVerificationKey } = require("../verifier/verifier.js")
 
-module.exports = async ({ deployments, getNamedAccounts, network }) => {
+async function deployVerifier({ deployments, getNamedAccounts }) {
   const { deployer } = await getNamedAccounts()
   const verificationKey = loadVerificationKey(network.name)
-  await deployments.deploy("Groth16Verifier", { args: [verificationKey], from: deployer })
+  await deployments.deploy("Groth16Verifier", {
+    args: [verificationKey],
+    from: deployer,
+  })
 }
 
-module.exports.tags = ["Groth16Verifier"]
+async function deployTestVerifier({ network, deployments, getNamedAccounts }) {
+  if (network.tags.local) {
+    const { deployer } = await getNamedAccounts()
+    await deployments.deploy("TestVerifier", { from: deployer })
+  }
+}
+
+module.exports = async (environment) => {
+  await deployVerifier(environment)
+  await deployTestVerifier(environment)
+}
+
+module.exports.tags = ["Verifier"]

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -6,6 +6,7 @@ const {
   exampleConfiguration,
   exampleRequest,
   exampleProof,
+  invalidProof,
 } = require("./examples")
 const { periodic, hours } = require("./time")
 const { requestId, slotId, askToArray } = require("./ids")
@@ -219,9 +220,8 @@ describe("Marketplace", function () {
     })
 
     it("is rejected when proof is incorrect", async function () {
-      await verifier.setProofsAreValid(false)
       await expect(
-        marketplace.fillSlot(slot.request, slot.index, proof)
+        marketplace.fillSlot(slot.request, slot.index, invalidProof())
       ).to.be.revertedWith("Invalid proof")
     })
 

--- a/test/Proofs.test.js
+++ b/test/Proofs.test.js
@@ -30,7 +30,7 @@ describe("Proofs", function () {
     await snapshot()
     await ensureMinimumBlockHeight(256)
     const Proofs = await ethers.getContractFactory("TestProofs")
-    await deployments.fixture(["Groth16Verifier"])
+    await deployments.fixture(["Verifier"])
     const verifier = await deployments.get("Groth16Verifier")
     proofs = await Proofs.deploy(
       { period, timeout, downtime, zkeyHash: "" },

--- a/test/examples.js
+++ b/test/examples.js
@@ -46,4 +46,15 @@ const exampleProof = () => ({
   c: { x: 7, y: 8 },
 })
 
-module.exports = { exampleConfiguration, exampleRequest, exampleProof }
+const invalidProof = () => ({
+  a: { x: 0, y: 0 },
+  b: { x: [0, 0], y: [0, 0] },
+  c: { x: 0, y: 0 },
+})
+
+module.exports = {
+  exampleConfiguration,
+  exampleRequest,
+  exampleProof,
+  invalidProof,
+}


### PR DESCRIPTION
Deploy 2 versions of the marketplace (only on local network):
- Marketplace with Groth16 Verifier
- Marketplace with TestVerifier

The test verifier accepts all proofs, except when it has all 0 values. 
Necessary for testing the codex client, until we can generate real ZK proofs.

Removes the code that deploys contracts to a fixed address, because it doesn't seem to work, and I couldn't find a way to get it to work.