### PR TITLE
Refactor of the solidity Groth16 verifier

### DIFF
--- a/contracts/Groth16.sol
+++ b/contracts/Groth16.sol
@@ -2,16 +2,16 @@
 pragma solidity 0.8.23;
 
 struct G1Point {
-  uint x;
-  uint y;
+  uint256 x;
+  uint256 y;
 }
 
 // A field element F_{p^2} encoded as `real + i * imag`.
 // We chose to not represent this as an array of 2 numbers, because both Circom
 // and Ethereum EIP-197 encode to an array, but with conflicting encodings.
 struct Fp2Element {
-  uint real;
-  uint imag;
+  uint256 real;
+  uint256 imag;
 }
 
 struct G2Point {
@@ -28,6 +28,6 @@ struct Groth16Proof {
 interface IGroth16Verifier {
   function verify(
     Groth16Proof calldata proof,
-    uint[] calldata pubSignals
+    uint256[] calldata pubSignals
   ) external view returns (bool);
 }

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -131,8 +131,11 @@ contract Groth16Verifier is IGroth16Verifier {
     Groth16Proof calldata proof,
     uint[] memory input
   ) public view returns (bool success) {
-    require(input.length + 1 == _verifyingKey.ic.length, "verifier-bad-input");
-    // Check that inputs are field elements
+    // Check amount of public inputs
+    if (input.length + 1 != _verifyingKey.ic.length) {
+      return false;
+    }
+    // Check that public inputs are field elements
     for (uint i = 0; i < input.length; i++) {
       if (input[i] >= _Q) {
         return false;
@@ -151,6 +154,7 @@ contract Groth16Verifier is IGroth16Verifier {
         return false;
       }
     }
+    // Check the pairing
     uint outcome;
     (success, outcome) = _checkPairing(
       _negate(proof.a),

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -160,12 +160,18 @@ contract Groth16Verifier {
       );
       G1Point memory product;
       (success, product) = Pairing.multiply(_verifyingKey.ic[i + 1], input[i]);
-      require(success, "pairing-mul-failed");
+      if (!success) {
+        return false;
+      }
       (success, vkX) = Pairing.add(vkX, product);
-      require(success, "pairing-add-failed");
+      if (!success) {
+        return false;
+      }
     }
     (success, vkX) = Pairing.add(vkX, _verifyingKey.ic[0]);
-    require(success, "pairing-add-failed");
+    if (!success) {
+      return false;
+    }
     uint outcome;
     (success, outcome) =
       Pairing.pairingProd4(
@@ -178,7 +184,9 @@ contract Groth16Verifier {
         proof.c,
         _verifyingKey.delta2
       );
-    require(success, "pairing-opcode-failed");
+    if (!success) {
+      return false;
+    }
     return outcome == 1;
   }
 }

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -122,14 +122,7 @@ contract Groth16Verifier {
 
     // solhint-disable-next-line no-inline-assembly
     assembly {
-      success := staticcall(
-        sub(gas(), 2000),
-        8,
-        input,
-        768, // 24 uints, 32 bytes each
-        output,
-        32
-      )
+      success := staticcall(sub(gas(), 2000), 8, input, 768, output, 32)
     }
     return (success, output[0]);
   }

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -27,8 +27,7 @@ library Pairing {
 
   /// The negation of p, i.e. p.addition(p.negate()) should be zero.
   function negate(G1Point memory p) internal pure returns (G1Point memory) {
-    if (p.x == 0 && p.y == 0) return G1Point(0, 0);
-    return G1Point(p.x, _Q - (p.y % _Q));
+    return G1Point(p.x, (_Q - p.y) % _Q);
   }
 
   /// The sum of two points of G1

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -21,7 +21,7 @@ pragma solidity 0.8.23;
 import "./Groth16.sol";
 
 contract Groth16Verifier is IGroth16Verifier {
-  uint private constant _P =
+  uint256 private constant _P =
     21888242871839275222246405745257275088696311157297823662689037894645226208583;
   uint256 private constant _R =
     21888242871839275222246405745257275088548364400416034343698204186575808495617;
@@ -54,7 +54,7 @@ contract Groth16Verifier is IGroth16Verifier {
     G1Point memory point1,
     G1Point memory point2
   ) private view returns (bool success, G1Point memory sum) {
-    uint[4] memory input;
+    uint256[4] memory input;
     input[0] = point1.x;
     input[1] = point1.y;
     input[2] = point2.x;
@@ -67,9 +67,9 @@ contract Groth16Verifier is IGroth16Verifier {
 
   function _multiply(
     G1Point memory point,
-    uint scalar
+    uint256 scalar
   ) private view returns (bool success, G1Point memory product) {
-    uint[3] memory input;
+    uint256[3] memory input;
     input[0] = point.x;
     input[1] = point.y;
     input[2] = scalar;
@@ -88,9 +88,9 @@ contract Groth16Verifier is IGroth16Verifier {
     G2Point memory c2,
     G1Point memory d1,
     G2Point memory d2
-  ) private view returns (bool success, uint outcome) {
-    uint[24] memory input; // 4 pairs of G1 and G2 points
-    uint[1] memory output;
+  ) private view returns (bool success, uint256 outcome) {
+    uint256[24] memory input; // 4 pairs of G1 and G2 points
+    uint256[1] memory output;
 
     input[0] = a1.x;
     input[1] = a1.y;
@@ -129,7 +129,7 @@ contract Groth16Verifier is IGroth16Verifier {
 
   function verify(
     Groth16Proof calldata proof,
-    uint[] memory input
+    uint256[] memory input
   ) public view returns (bool success) {
     // Check amount of public inputs
     if (input.length + 1 != _verifyingKey.ic.length) {
@@ -155,7 +155,7 @@ contract Groth16Verifier is IGroth16Verifier {
       }
     }
     // Check the pairing
-    uint outcome;
+    uint256 outcome;
     (success, outcome) = _checkPairing(
       _negate(proof.a),
       proof.b,

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -20,7 +20,7 @@
 pragma solidity 0.8.23;
 import "./Groth16.sol";
 
-contract Groth16Verifier {
+contract Groth16Verifier is IGroth16Verifier {
   uint private constant _P =
     21888242871839275222246405745257275088696311157297823662689037894645226208583;
   uint256 private constant _Q =

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -32,10 +32,10 @@ library Pairing {
   }
 
   /// The sum of two points of G1
-  function addition(
+  function add(
     G1Point memory p1,
     G1Point memory p2
-  ) internal view returns (G1Point memory r) {
+  ) internal view returns (G1Point memory sum) {
     uint[4] memory input;
     input[0] = p1.x;
     input[1] = p1.y;
@@ -51,10 +51,10 @@ library Pairing {
 
   /// The product of a point on G1 and a scalar, i.e.
   /// p == p.scalarMul(1) and p.addition(p) == p.scalarMul(2) for all points p.
-  function scalarMul(
+  function multiply(
     G1Point memory p,
     uint s
-  ) internal view returns (G1Point memory r) {
+  ) internal view returns (G1Point memory product) {
     uint[3] memory input;
     input[0] = p.x;
     input[1] = p.y;
@@ -164,12 +164,12 @@ contract Groth16Verifier {
         input[i] < _SNARK_SCALAR_FIELD,
         "verifier-gte-snark-scalar-field"
       );
-      vkX = Pairing.addition(
+      vkX = Pairing.add(
         vkX,
-        Pairing.scalarMul(_verifyingKey.ic[i + 1], input[i])
+        Pairing.multiply(_verifyingKey.ic[i + 1], input[i])
       );
     }
-    vkX = Pairing.addition(vkX, _verifyingKey.ic[0]);
+    vkX = Pairing.add(vkX, _verifyingKey.ic[0]);
     return
       Pairing.pairingProd4(
         Pairing.negate(proof.a),

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -139,13 +139,15 @@ contract Groth16Verifier {
     uint[] memory input
   ) public view returns (bool success) {
     require(input.length + 1 == _verifyingKey.ic.length, "verifier-bad-input");
+    // Check that inputs are field elements
+    for (uint i = 0; i < input.length; i++) {
+      if (input[i] >= _Q) {
+        return false;
+      }
+    }
     // Compute the linear combination vkX
     G1Point memory vkX = G1Point(0, 0);
     for (uint i = 0; i < input.length; i++) {
-      require(
-        input[i] < _Q,
-        "verifier-gte-snark-scalar-field"
-      );
       G1Point memory product;
       (success, product) = _multiply(_verifyingKey.ic[i + 1], input[i]);
       if (!success) {

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -23,7 +23,7 @@ import "./Groth16.sol";
 contract Groth16Verifier is IGroth16Verifier {
   uint private constant _P =
     21888242871839275222246405745257275088696311157297823662689037894645226208583;
-  uint256 private constant _Q =
+  uint256 private constant _R =
     21888242871839275222246405745257275088548364400416034343698204186575808495617;
 
   VerifyingKey private _verifyingKey;
@@ -137,7 +137,7 @@ contract Groth16Verifier is IGroth16Verifier {
     }
     // Check that public inputs are field elements
     for (uint i = 0; i < input.length; i++) {
-      if (input[i] >= _Q) {
+      if (input[i] >= _R) {
         return false;
       }
     }

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -20,7 +20,7 @@
 pragma solidity 0.8.23;
 import "./Groth16.sol";
 
-library Pairing {
+contract Groth16Verifier {
   // The prime q in the base field F_q for G1
   uint private constant _Q =
     21888242871839275222246405745257275088696311157297823662689037894645226208583;
@@ -72,7 +72,6 @@ library Pairing {
     G1Point memory d1,
     G2Point memory d2
   ) internal view returns (bool success, uint outcome) {
-
     uint[24] memory input; // 4 pairs of G1 and G2 points
     uint[1] memory output;
 
@@ -117,10 +116,7 @@ library Pairing {
     }
     return (success, output[0]);
   }
-}
 
-contract Groth16Verifier {
-  using Pairing for *;
   uint256 private constant _SNARK_SCALAR_FIELD =
     21888242871839275222246405745257275088548364400416034343698204186575808495617;
   VerifyingKey private _verifyingKey;
@@ -155,23 +151,23 @@ contract Groth16Verifier {
         "verifier-gte-snark-scalar-field"
       );
       G1Point memory product;
-      (success, product) = Pairing.multiply(_verifyingKey.ic[i + 1], input[i]);
+      (success, product) = multiply(_verifyingKey.ic[i + 1], input[i]);
       if (!success) {
         return false;
       }
-      (success, vkX) = Pairing.add(vkX, product);
+      (success, vkX) = add(vkX, product);
       if (!success) {
         return false;
       }
     }
-    (success, vkX) = Pairing.add(vkX, _verifyingKey.ic[0]);
+    (success, vkX) = add(vkX, _verifyingKey.ic[0]);
     if (!success) {
       return false;
     }
     uint outcome;
     (success, outcome) =
-      Pairing.checkPairing(
-        Pairing.negate(proof.a),
+      checkPairing(
+        negate(proof.a),
         proof.b,
         _verifyingKey.alpha1,
         _verifyingKey.beta2,

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -21,10 +21,9 @@ pragma solidity 0.8.23;
 import "./Groth16.sol";
 
 contract Groth16Verifier {
-  // The prime q in the base field F_q for G1
-  uint private constant _Q =
+  uint private constant _P =
     21888242871839275222246405745257275088696311157297823662689037894645226208583;
-  uint256 private constant _SNARK_SCALAR_FIELD =
+  uint256 private constant _Q =
     21888242871839275222246405745257275088548364400416034343698204186575808495617;
 
   VerifyingKey private _verifyingKey;
@@ -49,7 +48,7 @@ contract Groth16Verifier {
 
   /// The negation of p, i.e. p.addition(p.negate()) should be zero.
   function negate(G1Point memory p) internal pure returns (G1Point memory) {
-    return G1Point(p.x, (_Q - p.y) % _Q);
+    return G1Point(p.x, (_P - p.y) % _P);
   }
 
   /// The sum of two points of G1
@@ -148,7 +147,7 @@ contract Groth16Verifier {
     G1Point memory vkX = G1Point(0, 0);
     for (uint i = 0; i < input.length; i++) {
       require(
-        input[i] < _SNARK_SCALAR_FIELD,
+        input[i] < _Q,
         "verifier-gte-snark-scalar-field"
       );
       G1Point memory product;

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -54,6 +54,10 @@ contract Groth16Verifier is IGroth16Verifier {
     G1Point memory point1,
     G1Point memory point2
   ) private view returns (bool success, G1Point memory sum) {
+    // Call the precompiled contract for addition on the alt_bn128 curve.
+    // The call will fail if the points are not valid group elements:
+    // https://eips.ethereum.org/EIPS/eip-196#exact-semantics
+
     uint256[4] memory input;
     input[0] = point1.x;
     input[1] = point1.y;
@@ -69,6 +73,10 @@ contract Groth16Verifier is IGroth16Verifier {
     G1Point memory point,
     uint256 scalar
   ) private view returns (bool success, G1Point memory product) {
+    // Call the precompiled contract for scalar multiplication on the alt_bn128
+    // curve. The call will fail if the points are not valid group elements:
+    // https://eips.ethereum.org/EIPS/eip-196#exact-semantics
+
     uint256[3] memory input;
     input[0] = point.x;
     input[1] = point.y;
@@ -89,6 +97,10 @@ contract Groth16Verifier is IGroth16Verifier {
     G1Point memory d1,
     G2Point memory d2
   ) private view returns (bool success, uint256 outcome) {
+    // Call the precompiled contract for pairing check on the alt_bn128 curve.
+    // The call will fail if the points are not valid group elements:
+    // https://eips.ethereum.org/EIPS/eip-197#specification
+
     uint256[24] memory input; // 4 pairs of G1 and G2 points
     uint256[1] memory output;
 

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -138,15 +138,15 @@ contract Groth16Verifier {
         return false;
       }
     }
-    // Compute the linear combination vkX
-    G1Point memory vkX = _verifyingKey.ic[0];
+    // Compute the linear combination
+    G1Point memory combination = _verifyingKey.ic[0];
     for (uint i = 0; i < input.length; i++) {
       G1Point memory product;
       (success, product) = _multiply(_verifyingKey.ic[i + 1], input[i]);
       if (!success) {
         return false;
       }
-      (success, vkX) = _add(vkX, product);
+      (success, combination) = _add(combination, product);
       if (!success) {
         return false;
       }
@@ -157,7 +157,7 @@ contract Groth16Verifier {
       proof.b,
       _verifyingKey.alpha1,
       _verifyingKey.beta2,
-      vkX,
+      combination,
       _verifyingKey.gamma2,
       proof.c,
       _verifyingKey.delta2

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -24,6 +24,28 @@ contract Groth16Verifier {
   // The prime q in the base field F_q for G1
   uint private constant _Q =
     21888242871839275222246405745257275088696311157297823662689037894645226208583;
+  uint256 private constant _SNARK_SCALAR_FIELD =
+    21888242871839275222246405745257275088548364400416034343698204186575808495617;
+
+  VerifyingKey private _verifyingKey;
+
+  struct VerifyingKey {
+    G1Point alpha1;
+    G2Point beta2;
+    G2Point gamma2;
+    G2Point delta2;
+    G1Point[] ic;
+  }
+
+  constructor(VerifyingKey memory key) {
+    _verifyingKey.alpha1 = key.alpha1;
+    _verifyingKey.beta2 = key.beta2;
+    _verifyingKey.gamma2 = key.gamma2;
+    _verifyingKey.delta2 = key.delta2;
+    for (uint i = 0; i < key.ic.length; i++) {
+      _verifyingKey.ic.push(key.ic[i]);
+    }
+  }
 
   /// The negation of p, i.e. p.addition(p.negate()) should be zero.
   function negate(G1Point memory p) internal pure returns (G1Point memory) {
@@ -117,27 +139,6 @@ contract Groth16Verifier {
     return (success, output[0]);
   }
 
-  uint256 private constant _SNARK_SCALAR_FIELD =
-    21888242871839275222246405745257275088548364400416034343698204186575808495617;
-  VerifyingKey private _verifyingKey;
-  struct VerifyingKey {
-    G1Point alpha1;
-    G2Point beta2;
-    G2Point gamma2;
-    G2Point delta2;
-    G1Point[] ic;
-  }
-
-  constructor(VerifyingKey memory key) {
-    _verifyingKey.alpha1 = key.alpha1;
-    _verifyingKey.beta2 = key.beta2;
-    _verifyingKey.gamma2 = key.gamma2;
-    _verifyingKey.delta2 = key.delta2;
-    for (uint i = 0; i < key.ic.length; i++) {
-      _verifyingKey.ic.push(key.ic[i]);
-    }
-  }
-
   function verify(
     Groth16Proof calldata proof,
     uint[] memory input
@@ -165,17 +166,16 @@ contract Groth16Verifier {
       return false;
     }
     uint outcome;
-    (success, outcome) =
-      checkPairing(
-        negate(proof.a),
-        proof.b,
-        _verifyingKey.alpha1,
-        _verifyingKey.beta2,
-        vkX,
-        _verifyingKey.gamma2,
-        proof.c,
-        _verifyingKey.delta2
-      );
+    (success, outcome) = checkPairing(
+      negate(proof.a),
+      proof.b,
+      _verifyingKey.alpha1,
+      _verifyingKey.beta2,
+      vkX,
+      _verifyingKey.gamma2,
+      proof.c,
+      _verifyingKey.delta2
+    );
     if (!success) {
       return false;
     }

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -65,7 +65,7 @@ contract Groth16Verifier is IGroth16Verifier {
     input[3] = point2.y;
     // solhint-disable-next-line no-inline-assembly
     assembly {
-      success := staticcall(sub(gas(), 2000), 6, input, 128, sum, 64)
+      success := staticcall(gas(), 6, input, 128, sum, 64)
     }
   }
 
@@ -83,7 +83,7 @@ contract Groth16Verifier is IGroth16Verifier {
     input[2] = scalar;
     // solhint-disable-next-line no-inline-assembly
     assembly {
-      success := staticcall(sub(gas(), 2000), 7, input, 96, product, 64)
+      success := staticcall(gas(), 7, input, 96, product, 64)
     }
   }
 
@@ -134,7 +134,7 @@ contract Groth16Verifier is IGroth16Verifier {
 
     // solhint-disable-next-line no-inline-assembly
     assembly {
-      success := staticcall(sub(gas(), 2000), 8, input, 768, output, 32)
+      success := staticcall(gas(), 8, input, 768, output, 32)
     }
     return (success, output[0]);
   }

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -45,11 +45,6 @@ library Pairing {
     // solhint-disable-next-line no-inline-assembly
     assembly {
       success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
-      // Use "invalid" to make gas estimation work
-      switch success
-      case 0 {
-        invalid()
-      }
     }
     require(success, "pairing-add-failed");
   }
@@ -68,11 +63,6 @@ library Pairing {
     // solhint-disable-next-line no-inline-assembly
     assembly {
       success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
-      // Use "invalid" to make gas estimation work
-      switch success
-      case 0 {
-        invalid()
-      }
     }
     require(success, "pairing-mul-failed");
   }
@@ -109,11 +99,6 @@ library Pairing {
         out,
         0x20
       )
-      // Use "invalid" to make gas estimation work
-      switch success
-      case 0 {
-        invalid()
-      }
     }
     require(success, "pairing-opcode-failed");
     return out[0] != 0;

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -44,7 +44,7 @@ library Pairing {
     bool success;
     // solhint-disable-next-line no-inline-assembly
     assembly {
-      success := staticcall(sub(gas(), 2000), 6, input, 0xc0, r, 0x60)
+      success := staticcall(sub(gas(), 2000), 6, input, 128, sum, 64)
     }
     require(success, "pairing-add-failed");
   }
@@ -62,7 +62,7 @@ library Pairing {
     bool success;
     // solhint-disable-next-line no-inline-assembly
     assembly {
-      success := staticcall(sub(gas(), 2000), 7, input, 0x80, r, 0x60)
+      success := staticcall(sub(gas(), 2000), 7, input, 96, product, 64)
     }
     require(success, "pairing-mul-failed");
   }
@@ -94,10 +94,10 @@ library Pairing {
       success := staticcall(
         sub(gas(), 2000),
         8,
-        add(input, 0x20),
-        mul(inputSize, 0x20),
+        add(input, 32),
+        mul(inputSize, 32),
         out,
-        0x20
+        32
       )
     }
     require(success, "pairing-opcode-failed");

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -46,37 +46,33 @@ contract Groth16Verifier {
     }
   }
 
-  /// The negation of p, i.e. p.addition(p.negate()) should be zero.
-  function negate(G1Point memory p) internal pure returns (G1Point memory) {
-    return G1Point(p.x, (_P - p.y) % _P);
+  function negate(G1Point memory point) internal pure returns (G1Point memory) {
+    return G1Point(point.x, (_P - point.y) % _P);
   }
 
-  /// The sum of two points of G1
   function add(
-    G1Point memory p1,
-    G1Point memory p2
+    G1Point memory point1,
+    G1Point memory point2
   ) internal view returns (bool success, G1Point memory sum) {
     uint[4] memory input;
-    input[0] = p1.x;
-    input[1] = p1.y;
-    input[2] = p2.x;
-    input[3] = p2.y;
+    input[0] = point1.x;
+    input[1] = point1.y;
+    input[2] = point2.x;
+    input[3] = point2.y;
     // solhint-disable-next-line no-inline-assembly
     assembly {
       success := staticcall(sub(gas(), 2000), 6, input, 128, sum, 64)
     }
   }
 
-  /// The product of a point on G1 and a scalar, i.e.
-  /// p == p.scalarMul(1) and p.addition(p) == p.scalarMul(2) for all points p.
   function multiply(
-    G1Point memory p,
-    uint s
+    G1Point memory point,
+    uint scalar
   ) internal view returns (bool success, G1Point memory product) {
     uint[3] memory input;
-    input[0] = p.x;
-    input[1] = p.y;
-    input[2] = s;
+    input[0] = point.x;
+    input[1] = point.y;
+    input[2] = scalar;
     // solhint-disable-next-line no-inline-assembly
     assembly {
       success := staticcall(sub(gas(), 2000), 7, input, 96, product, 64)

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -46,14 +46,14 @@ contract Groth16Verifier {
     }
   }
 
-  function negate(G1Point memory point) internal pure returns (G1Point memory) {
+  function _negate(G1Point memory point) private pure returns (G1Point memory) {
     return G1Point(point.x, (_P - point.y) % _P);
   }
 
-  function add(
+  function _add(
     G1Point memory point1,
     G1Point memory point2
-  ) internal view returns (bool success, G1Point memory sum) {
+  ) private view returns (bool success, G1Point memory sum) {
     uint[4] memory input;
     input[0] = point1.x;
     input[1] = point1.y;
@@ -65,10 +65,10 @@ contract Groth16Verifier {
     }
   }
 
-  function multiply(
+  function _multiply(
     G1Point memory point,
     uint scalar
-  ) internal view returns (bool success, G1Point memory product) {
+  ) private view returns (bool success, G1Point memory product) {
     uint[3] memory input;
     input[0] = point.x;
     input[1] = point.y;
@@ -79,7 +79,7 @@ contract Groth16Verifier {
     }
   }
 
-  function checkPairing(
+  function _checkPairing(
     G1Point memory a1,
     G2Point memory a2,
     G1Point memory b1,
@@ -88,7 +88,7 @@ contract Groth16Verifier {
     G2Point memory c2,
     G1Point memory d1,
     G2Point memory d2
-  ) internal view returns (bool success, uint outcome) {
+  ) private view returns (bool success, uint outcome) {
     uint[24] memory input; // 4 pairs of G1 and G2 points
     uint[1] memory output;
 
@@ -147,22 +147,22 @@ contract Groth16Verifier {
         "verifier-gte-snark-scalar-field"
       );
       G1Point memory product;
-      (success, product) = multiply(_verifyingKey.ic[i + 1], input[i]);
+      (success, product) = _multiply(_verifyingKey.ic[i + 1], input[i]);
       if (!success) {
         return false;
       }
-      (success, vkX) = add(vkX, product);
+      (success, vkX) = _add(vkX, product);
       if (!success) {
         return false;
       }
     }
-    (success, vkX) = add(vkX, _verifyingKey.ic[0]);
+    (success, vkX) = _add(vkX, _verifyingKey.ic[0]);
     if (!success) {
       return false;
     }
     uint outcome;
-    (success, outcome) = checkPairing(
-      negate(proof.a),
+    (success, outcome) = _checkPairing(
+      _negate(proof.a),
       proof.b,
       _verifyingKey.alpha1,
       _verifyingKey.beta2,

--- a/contracts/Groth16Verifier.sol
+++ b/contracts/Groth16Verifier.sol
@@ -139,7 +139,7 @@ contract Groth16Verifier {
       }
     }
     // Compute the linear combination vkX
-    G1Point memory vkX = G1Point(0, 0);
+    G1Point memory vkX = _verifyingKey.ic[0];
     for (uint i = 0; i < input.length; i++) {
       G1Point memory product;
       (success, product) = _multiply(_verifyingKey.ic[i + 1], input[i]);
@@ -150,10 +150,6 @@ contract Groth16Verifier {
       if (!success) {
         return false;
       }
-    }
-    (success, vkX) = _add(vkX, _verifyingKey.ic[0]);
-    if (!success) {
-      return false;
     }
     uint outcome;
     (success, outcome) = _checkPairing(

--- a/test/Proofs.test.js
+++ b/test/Proofs.test.js
@@ -205,13 +205,16 @@ describe("Proofs", function () {
 
     it("fails proof submission when proof is incorrect", async function () {
       let invalid = exampleProof()
-      await expect(proofs.proofReceived(slotId, invalid, pubSignals)).to.be
-        .reverted
+      await expect(
+        proofs.proofReceived(slotId, invalid, pubSignals)
+      ).to.be.revertedWith("Invalid proof")
     })
 
     it("fails proof submission when public input is incorrect", async function () {
       let invalid = [1, 2, 3]
-      await expect(proofs.proofReceived(slotId, proof, invalid)).to.be.reverted
+      await expect(
+        proofs.proofReceived(slotId, proof, invalid)
+      ).to.be.revertedWith("Invalid proof")
     })
 
     it("emits an event when proof was submitted", async function () {


### PR DESCRIPTION
Refactors the Groth16 verifier to:
- fix mistakes
- remove unnecessary conversions
- make it more readable
- return false instead of stopping execution when an operation fails