### PR TITLE
Explicit getters for token and config

### DIFF
--- a/contracts/FuzzMarketplace.sol
+++ b/contracts/FuzzMarketplace.sol
@@ -32,6 +32,6 @@ contract FuzzMarketplace is Marketplace {
 
   function neverLoseFunds() public view {
     uint256 total = _marketplaceTotals.received - _marketplaceTotals.sent;
-    assert(token.balanceOf(address(this)) >= total);
+    assert(token().balanceOf(address(this)) >= total);
   }
 }


### PR DESCRIPTION
Implicit getters have slightly different semantics when it comes to ABI encoding their results.
This lead to a problem when calling the getter for the config that contains the zkeyHash string.

The decoding problem has been solved in https://github.com/codex-storage/nim-ethers/pull/63, but that is not ready to be merged yet, because it depends on the chronos v4 changes in nim-ethers.

This is a workaround that makes the getters explicit.