### PR TITLE
Increase proof period

### DIFF
--- a/deploy/marketplace.js
+++ b/deploy/marketplace.js
@@ -9,8 +9,10 @@ const CONFIGURATION = {
     slashPercentage: 10,
   },
   proofs: {
-    period: 10,
-    timeout: 5,
+    period: 60,
+    timeout: 30,
+    // `downtime` needs to be larger than `period` when running hardhat
+    // in automine mode, because it can produce a block every second
     downtime: 64,
   },
 }


### PR DESCRIPTION
In Codex's integration tests we now create real ZK proofs, which take a bit longer to generate. We therefore need a period that remains the same while the proof is generated.