### PR TITLE
Slash and free slot sooner when proofs are missed

### DIFF
--- a/deploy/marketplace.js
+++ b/deploy/marketplace.js
@@ -4,9 +4,9 @@ const { loadZkeyHash } = require("../verifier/verifier.js")
 const CONFIGURATION = {
   collateral: {
     repairRewardPercentage: 10,
-    maxNumberOfSlashes: 5,
-    slashCriterion: 3,
-    slashPercentage: 10,
+    maxNumberOfSlashes: 2,
+    slashCriterion: 2,
+    slashPercentage: 20,
   },
   proofs: {
     period: 60,


### PR DESCRIPTION
This makes it faster to test these scenarios in the codex integration tests.

(These configuration parameters are now specialized for our integration tests.
Pretty soon we'll probably want to have different configurations for distributed
testing, our testnet, etc. But that's something for another PR)