### PR TITLE
feat: expiry specified with number of seconds

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -32,6 +32,7 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
     uint256 expiryFundsWithdraw;
     uint256 startedAt;
     uint256 endsAt;
+    uint256 expiresAt;
   }
 
   struct Slot {
@@ -90,11 +91,14 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
 
     RequestId id = request.id();
     require(_requests[id].client == address(0), "Request already exists");
+    require(
+      request.expiry > 0 && request.expiry < request.ask.duration,
+      "Expiry not between 0 and duration"
+    );
 
     _requests[id] = request;
-    uint256 endsAt = block.timestamp + request.ask.duration;
-    require(endsAt > request.expiry, "Request end before expiry");
-    _requestContexts[id].endsAt = endsAt;
+    _requestContexts[id].endsAt = block.timestamp + request.ask.duration;
+    _requestContexts[id].expiresAt = block.timestamp + request.expiry;
 
     _addToMyRequests(request.client, id);
 
@@ -103,7 +107,7 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
     _marketplaceTotals.received += amount;
     _transferFrom(msg.sender, amount);
 
-    emit StorageRequested(id, request.ask, request.expiry);
+    emit StorageRequested(id, request.ask, _requestContexts[id].expiresAt);
   }
 
   function fillSlot(
@@ -286,7 +290,10 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
   /// @param requestId the id of the request
   function withdrawFunds(RequestId requestId) public {
     Request storage request = _requests[requestId];
-    require(block.timestamp > request.expiry, "Request not yet timed out");
+    require(
+      block.timestamp > requestExpiry(requestId),
+      "Request not yet timed out"
+    );
     require(request.client == msg.sender, "Invalid client address");
     RequestContext storage context = _requestContexts[requestId];
     require(context.state == RequestState.New, "Invalid state");
@@ -339,15 +346,22 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
     }
   }
 
+  function requestExpiry(RequestId requestId) public view returns (uint256) {
+    return _requestContexts[requestId].expiresAt;
+  }
+
   /// @notice Calculates the amount that should be payed out to a host if a request expires based on when the host fills the slot
   function _expiryPayoutAmount(
     RequestId requestId,
     uint256 startingTimestamp
   ) private view returns (uint256) {
     Request storage request = _requests[requestId];
-    require(startingTimestamp < request.expiry, "Start not before expiry");
+    require(
+      startingTimestamp < requestExpiry(requestId),
+      "Start not before expiry"
+    );
 
-    return (request.expiry - startingTimestamp) * request.ask.reward;
+    return (requestExpiry(requestId) - startingTimestamp) * request.ask.reward;
   }
 
   function getHost(SlotId slotId) public view returns (address) {
@@ -360,7 +374,7 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
     RequestContext storage context = _requestContexts[requestId];
     if (
       context.state == RequestState.New &&
-      block.timestamp > _requests[requestId].expiry
+      block.timestamp > requestExpiry(requestId)
     ) {
       return RequestState.Cancelled;
     } else if (

--- a/contracts/Requests.sol
+++ b/contracts/Requests.sol
@@ -8,7 +8,7 @@ struct Request {
   address client;
   Ask ask;
   Content content;
-  uint256 expiry; // timestamp as seconds since unix epoch at which this request expires
+  uint256 expiry; // amount of seconds since start of the request at which this request expires
   bytes32 nonce; // random nonce to differentiate between similar requests
 }
 

--- a/test/examples.js
+++ b/test/examples.js
@@ -1,6 +1,5 @@
 const { ethers } = require("hardhat")
 const { hours } = require("./time")
-const { currentTime } = require("./evm")
 const { hexlify, randomBytes } = ethers.utils
 
 const exampleConfiguration = () => ({
@@ -19,7 +18,6 @@ const exampleConfiguration = () => ({
 })
 
 const exampleRequest = async () => {
-  const now = await currentTime()
   return {
     client: hexlify(randomBytes(20)),
     ask: {
@@ -35,7 +33,7 @@ const exampleRequest = async () => {
       cid: "zb2rhheVmk3bLks5MgzTqyznLu1zqGH5jrfTA1eAZXrjx7Vob",
       merkleRoot: Array.from(randomBytes(32)),
     },
-    expiry: now + hours(1),
+    expiry: hours(1),
     nonce: hexlify(randomBytes(32)),
   }
 }

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -3,7 +3,7 @@ const { slotId, requestId } = require("./ids")
 const { price } = require("./price")
 
 async function waitUntilCancelled(request) {
-  await advanceTimeToForNextBlock(request.expiry + 1)
+  await advanceTimeToForNextBlock((await currentTime()) + request.expiry + 1)
 }
 
 async function waitUntilStarted(contract, request, proof, token) {

--- a/test/requests.js
+++ b/test/requests.js
@@ -1,4 +1,5 @@
 const { Assertion } = require("chai")
+const { currentTime } = require("./evm")
 
 const RequestState = {
   New: 0,
@@ -15,6 +16,10 @@ const SlotState = {
   Failed: 3,
   Paid: 4,
   Cancelled: 5,
+}
+
+async function requestExpectedExpiry(request) {
+  return (await currentTime()) + request.expiry + 1
 }
 
 const enableRequestAssertions = function () {
@@ -46,4 +51,9 @@ const enableRequestAssertions = function () {
   })
 }
 
-module.exports = { RequestState, SlotState, enableRequestAssertions }
+module.exports = {
+  RequestState,
+  SlotState,
+  enableRequestAssertions,
+  requestExpectedExpiry,
+}


### PR DESCRIPTION
This is part of the work on fixing https://github.com/codex-storage/nim-codex/issues/766.

Not completely sure why the `expiry` was designed in this way where a timestamp was passed, while `duration` is computed as `now + duration interval`. Originally for the fix mentioned above, I thought I would do this computation in `nim-codex` but I ran into a clock syncing issue in tests, so I have instead decided to do a proper fix with unifying the "time computation" in the smart contracts for expiry and duration in the same way.