### PR TITLE
chore(ci): update certora-cli version in CI tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           java-package: 'jre'
 
       - name: Install Certora CLI
-        run: pip3 install certora-cli==7.6.3
+        run: pip3 install certora-cli==7.10.1
 
       - name: Install Solidity
         run: |


### PR DESCRIPTION
This updates `certora-cli` to the latest version (at the time of the commit, this was 7.10.1).