### PR TITLE
ci: add ci job concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
+
 jobs:
   formatting:
     runs-on: ubuntu-latest
@@ -40,12 +41,15 @@ jobs:
           submodules: recursive
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with: { python-version: 3.9 }
 
       - name: Install Java
-        uses: actions/setup-java@v1
-        with: { java-version: "11", java-package: jre }
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: 'jre'
 
       - name: Install Certora CLI
         run: pip3 install certora-cli==7.6.3
@@ -56,17 +60,17 @@ jobs:
           chmod +x solc-static-linux
           sudo mv solc-static-linux /usr/local/bin/solc
 
-      - name: "Install Node.js"
-        uses: "actions/setup-node@v3"
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
-          cache: "npm"
+          cache: npm
           node-version: "lts/*"
 
-      - name: "Install the Node.js dependencies"
-        run: "npm install"
+      - name: Install the Node.js dependencies
+        run: npm install
 
       - name: Verify rules
-        run: "npm run verify"
+        run: npm run verify
         env:
           CERTORAKEY: ${{ secrets.CERTORAKEY }}
 


### PR DESCRIPTION
This PR is to save resources and add some order using [concurrency](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-concurrency). On Push/Pull request, previously running job will be canceled as [we do it for nim-codex](https://github.com/codex-storage/nim-codex/blob/4f56f2af26d77af1490ef499d487aad965ff70bf/.github/workflows/ci.yml#L15-L17)

We also updated actions to the latest releases to remove deprecation warnings
<img width="1143" alt="Screenshot 2024-07-31 at 14 03 18" src="https://github.com/user-attachments/assets/1d4cd7c5-7921-4524-832c-f9b921a2cee7">
