### PR TITLE
fix: ensure requestStorage() reverts if maxSlotloss > slots

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -95,6 +95,10 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
       request.expiry > 0 && request.expiry < request.ask.duration,
       "Expiry not in range"
     );
+    require(
+      request.ask.maxSlotLoss <= request.ask.slots,
+      "maxSlotLoss exceeds slots"
+    );
 
     _requests[id] = request;
     _requestContexts[id].endsAt = block.timestamp + request.ask.duration;

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -185,6 +185,13 @@ describe("Marketplace", function () {
       )
     })
 
+    it("is rejected when maxSlotLoss exceeds slots", async function () {
+      request.ask.maxSlotLoss = request.ask.slots + 1
+      await expect(marketplace.requestStorage(request)).to.be.revertedWith(
+        "maxSlotLoss exceeds slots"
+      )
+    })
+
     it("rejects resubmission of request", async function () {
       await token.approve(marketplace.address, price(request) * 2)
       await marketplace.requestStorage(request)


### PR DESCRIPTION
`request.ask.maxSlotLoss` has to be less or equal to `slots`. This check was missing, so this commit adds it and provdes a test to confirm this as well.

Fixes #139