### PR TITLE
feat: adds an optional `payoutAddress` to allow payouts to be paid to separate address

### DIFF
--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -111,7 +111,7 @@ function canStartRequest(method f) returns bool {
 }
 
 function canFinishRequest(method f) returns bool {
-    return f.selector == sig:freeSlot(Marketplace.SlotId).selector;
+    return f.selector == sig:freeSlot(Marketplace.SlotId, address).selector;
 }
 
 function canFailRequest(method f) returns bool {

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -103,7 +103,7 @@ hook Sstore _slots[KEY Marketplace.SlotId slotId].state Marketplace.SlotState ne
 --------------------------------------------*/
 
 function canCancelRequest(method f) returns bool {
-    return f.selector == sig:withdrawFunds(Marketplace.RequestId).selector;
+    return f.selector == sig:withdrawFunds(Marketplace.RequestId, address).selector;
 }
 
 function canStartRequest(method f) returns bool {

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -103,7 +103,7 @@ hook Sstore _slots[KEY Marketplace.SlotId slotId].state Marketplace.SlotState ne
 --------------------------------------------*/
 
 function canCancelRequest(method f) returns bool {
-    return f.selector == sig:withdrawFunds(Marketplace.RequestId, address).selector;
+    return f.selector == sig:withdrawFunds(Marketplace.RequestId).selector;
 }
 
 function canStartRequest(method f) returns bool {
@@ -111,12 +111,12 @@ function canStartRequest(method f) returns bool {
 }
 
 function canFinishRequest(method f) returns bool {
-    return f.selector == sig:freeSlot(Marketplace.SlotId, address).selector;
+    return f.selector == sig:freeSlot(Marketplace.SlotId, address, address).selector;
 }
 
 function canFailRequest(method f) returns bool {
     return f.selector == sig:markProofAsMissing(Marketplace.SlotId, Periods.Period).selector ||
-        f.selector == sig:freeSlot(Marketplace.SlotId).selector;
+        f.selector == sig:freeSlot(Marketplace.SlotId, address, address).selector;
 }
 
 /*--------------------------------------------

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -116,25 +116,6 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
   }
 
   /**
-   * @notice Fills a slot with the payout address set to the address of the host
-     filling the slot.
-   * @param requestId RequestId identifying the request containing the slot to
-     fill.
-   * @param slotIndex Index of the slot in the request.
-   * @param proof Groth16 proof procing possession of the slot data.
-   * @dev This overload is an alternative way of providing an optional parameter
-     for payoutAddress, used for instances where a host does not specify a
-     separate payout address.
-   */
-  function fillSlot(
-    RequestId requestId,
-    uint256 slotIndex,
-    Groth16Proof calldata proof
-  ) public requestIsKnown(requestId) {
-    fillSlot(requestId, slotIndex, proof, msg.sender);
-  }
-
-  /**
    * @notice Fills a slot. Reverts if an invalid proof of the slot data is
      provided.
    * @param requestId RequestId identifying the request containing the slot to

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -330,7 +330,8 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
      transaction must originate from the depositer address.
    * @param requestId the id of the request
    */
-  function withdrawFunds(RequestId requestId) public {
+  /// @param withdrawAddress the address to withdraw funds to
+  function withdrawFunds(RequestId requestId, address withdrawAddress) public {
     Request storage request = _requests[requestId];
     require(
       block.timestamp > requestExpiry(requestId),
@@ -349,7 +350,7 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
 
     uint256 amount = context.expiryFundsWithdraw;
     _marketplaceTotals.sent += amount;
-    assert(_token.transfer(msg.sender, amount));
+    assert(_token.transfer(withdrawAddress, amount));
   }
 
   function getActiveSlot(

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -115,6 +115,35 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
     emit StorageRequested(id, request.ask, _requestContexts[id].expiresAt);
   }
 
+  /**
+   * @notice Fills a slot with the payout address set to the address of the host
+     filling the slot.
+   * @param requestId RequestId identifying the request containing the slot to
+     fill.
+   * @param slotIndex Index of the slot in the request.
+   * @param proof Groth16 proof procing possession of the slot data.
+   * @dev This overload is an alternative way of providing an optional parameter
+     for payoutAddress, used for instances where a host does not specify a
+     separate payout address.
+   */
+  function fillSlot(
+    RequestId requestId,
+    uint256 slotIndex,
+    Groth16Proof calldata proof
+  ) public requestIsKnown(requestId) {
+    fillSlot(requestId, slotIndex, proof, msg.sender);
+  }
+
+  /**
+   * @notice Fills a slot. Reverts if an invalid proof of the slot data is
+     provided.
+   * @param requestId RequestId identifying the request containing the slot to
+     fill.
+   * @param slotIndex Index of the slot in the request.
+   * @param proof Groth16 proof procing possession of the slot data.
+   * @param payoutAddress Address to send reward payouts to upon request
+     conclusion.
+   */
   function fillSlot(
     RequestId requestId,
     uint256 slotIndex,

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -327,7 +327,7 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
   /**
    * @notice Pays out a host for duration of time that the slot was filled, and
      returns the collateral.
-   * @dev The payouts are sent to the payoutAddress, and collateral is returned
+   * @dev The payouts are sent to the rewardRecipient, and collateral is returned
      to the host address.
    * @param requestId RequestId of the request that contains the slot to be paid
      out.

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -87,7 +87,7 @@ describe("Marketplace", function () {
   let marketplace
   let token
   let verifier
-  let client, host, host1, host2, host3
+  let client, clientPayout, host, host1, host2, host3, hostPayout
   let request
   let slot
 
@@ -96,12 +96,12 @@ describe("Marketplace", function () {
   beforeEach(async function () {
     await snapshot()
     await ensureMinimumBlockHeight(256)
-    ;[client, host1, host2, host3] = await ethers.getSigners()
+    ;[client, clientPayout, host1, host2, host3, hostPayout] = await ethers.getSigners()
     host = host1
 
     const TestToken = await ethers.getContractFactory("TestToken")
     token = await TestToken.deploy()
-    for (let account of [client, host1, host2, host3]) {
+    for (let account of [client, clientPayout, host1, host2, host3, hostPayout]) {
       await token.mint(account.address, ACCOUNT_STARTING_BALANCE)
     }
 
@@ -474,10 +474,10 @@ describe("Marketplace", function () {
       await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
       const startBalanceHostAddr = await token.balanceOf(host.address)
-      const startBalancePayoutAddr = await token.balanceOf(host2.address)
-      await marketplace.freeSlot(slotId(slot), host2.address)
+      const startBalancePayoutAddr = await token.balanceOf(hostPayout.address)
+      await marketplace.freeSlot(slotId(slot), hostPayout.address)
       const endBalanceHostAddr = await token.balanceOf(host.address)
-      const endBalancePayoutAddr = await token.balanceOf(host2.address)
+      const endBalancePayoutAddr = await token.balanceOf(hostPayout.address)
       expect(endBalanceHostAddr - startBalanceHostAddr).to.equal(
         request.ask.collateral
       )
@@ -486,7 +486,7 @@ describe("Marketplace", function () {
       )
     })
 
-    it("pays to host payoutAddress when contract was cancelled, and returns collateral to host address", async function () {
+    it("pays to host payout address when contract was cancelled, and returns collateral to host address", async function () {
       // Lets advance the time more into the expiry window
       const filledAt = (await currentTime()) + Math.floor(request.expiry / 3)
       const expiresAt = (
@@ -497,10 +497,10 @@ describe("Marketplace", function () {
       await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(request)
       const startBalanceHostAddr = await token.balanceOf(host.address)
-      await marketplace.freeSlot(slotId(slot), host2.address)
+      await marketplace.freeSlot(slotId(slot), hostPayout.address)
 
       const expectedPartialPayout = (expiresAt - filledAt) * request.ask.reward
-      const endBalancePayoutAddr = await token.balanceOf(host2.address)
+      const endBalancePayoutAddr = await token.balanceOf(hostPayout.address)
       expect(endBalancePayoutAddr - ACCOUNT_STARTING_BALANCE).to.be.equal(
         expectedPartialPayout
       )
@@ -513,10 +513,10 @@ describe("Marketplace", function () {
     it("does not pay when the contract hasn't ended", async function () {
       await marketplace.fillSlot(slot.request, slot.index, proof)
       const startBalanceHost = await token.balanceOf(host.address)
-      const startBalancePayout = await token.balanceOf(host2.address)
-      await marketplace.freeSlot(slotId(slot), host2.address)
+      const startBalancePayout = await token.balanceOf(hostPayout.address)
+      await marketplace.freeSlot(slotId(slot), hostPayout.address)
       const endBalanceHost = await token.balanceOf(host.address)
-      const endBalancePayout = await token.balanceOf(host2.address)
+      const endBalancePayout = await token.balanceOf(hostPayout.address)
       expect(endBalanceHost).to.equal(startBalanceHost)
       expect(endBalancePayout).to.equal(startBalancePayout)
     })
@@ -599,14 +599,14 @@ describe("Marketplace", function () {
 
     it("rejects withdraw when request not yet timed out", async function () {
       switchAccount(client)
-      await expect(marketplace.withdrawFunds(slot.request)).to.be.revertedWith(
+      await expect(marketplace.withdrawFunds(slot.request, clientPayout.address)).to.be.revertedWith(
         "Request not yet timed out"
       )
     })
 
     it("rejects withdraw when wrong account used", async function () {
       await waitUntilCancelled(request)
-      await expect(marketplace.withdrawFunds(slot.request)).to.be.revertedWith(
+      await expect(marketplace.withdrawFunds(slot.request, clientPayout.address)).to.be.revertedWith(
         "Invalid client address"
       )
     })
@@ -623,7 +623,7 @@ describe("Marketplace", function () {
       }
       await waitUntilCancelled(request)
       switchAccount(client)
-      await expect(marketplace.withdrawFunds(slot.request)).to.be.revertedWith(
+      await expect(marketplace.withdrawFunds(slot.request, clientPayout.address)).to.be.revertedWith(
         "Invalid state"
       )
     })
@@ -631,21 +631,24 @@ describe("Marketplace", function () {
     it("emits event once request is cancelled", async function () {
       await waitUntilCancelled(request)
       switchAccount(client)
-      await expect(marketplace.withdrawFunds(slot.request))
+      await expect(marketplace.withdrawFunds(slot.request, clientPayout.address))
         .to.emit(marketplace, "RequestCancelled")
         .withArgs(requestId(request))
     })
 
-    it("withdraws to the client", async function () {
+    it("withdraws to the client payout address", async function () {
       await waitUntilCancelled(request)
       switchAccount(client)
-      const startBalance = await token.balanceOf(client.address)
-      await marketplace.withdrawFunds(slot.request)
-      const endBalance = await token.balanceOf(client.address)
-      expect(endBalance - startBalance).to.equal(price(request))
+      const startBalanceClient = await token.balanceOf(client.address)
+      const startBalancePayout = await token.balanceOf(clientPayout.address)
+      await marketplace.withdrawFunds(slot.request, clientPayout.address)
+      const endBalanceClient = await token.balanceOf(client.address)
+      const endBalancePayout = await token.balanceOf(clientPayout.address)
+      expect(endBalanceClient).to.equal(startBalanceClient)
+      expect(endBalancePayout - startBalancePayout).to.equal(price(request))
     })
 
-    it("withdraws to the client for cancelled requests lowered by hosts payout", async function () {
+    it("withdraws to the client payout address for cancelled requests lowered by hosts payout", async function () {
       // Lets advance the time more into the expiry window
       const filledAt = (await currentTime()) + Math.floor(request.expiry / 3)
       const expiresAt = (
@@ -659,10 +662,10 @@ describe("Marketplace", function () {
         (expiresAt - filledAt) * request.ask.reward
 
       switchAccount(client)
-      await marketplace.withdrawFunds(slot.request)
-      const endBalance = await token.balanceOf(client.address)
-      expect(ACCOUNT_STARTING_BALANCE - endBalance).to.equal(
-        expectedPartialHostPayout
+      await marketplace.withdrawFunds(slot.request, clientPayout.address)
+      const endBalance = await token.balanceOf(clientPayout.address)
+      expect(endBalance - ACCOUNT_STARTING_BALANCE).to.equal(
+        price(request) - expectedPartialHostPayout
       )
     })
   })
@@ -691,7 +694,7 @@ describe("Marketplace", function () {
     it("remains 'Cancelled' when client withdraws funds", async function () {
       await waitUntilCancelled(request)
       switchAccount(client)
-      await marketplace.withdrawFunds(slot.request)
+      await marketplace.withdrawFunds(slot.request, clientPayout.address)
       expect(await marketplace.requestState(slot.request)).to.equal(Cancelled)
     })
 
@@ -1044,7 +1047,7 @@ describe("Marketplace", function () {
     it("removes request from list when funds are withdrawn", async function () {
       await marketplace.requestStorage(request)
       await waitUntilCancelled(request)
-      await marketplace.withdrawFunds(requestId(request))
+      await marketplace.withdrawFunds(requestId(request), clientPayout.address)
       expect(await marketplace.myRequests()).to.deep.equal([])
     })
 

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -96,12 +96,20 @@ describe("Marketplace", function () {
   beforeEach(async function () {
     await snapshot()
     await ensureMinimumBlockHeight(256)
-    ;[client, clientPayout, host1, host2, host3, hostPayout] = await ethers.getSigners()
+    ;[client, clientPayout, host1, host2, host3, hostPayout] =
+      await ethers.getSigners()
     host = host1
 
     const TestToken = await ethers.getContractFactory("TestToken")
     token = await TestToken.deploy()
-    for (let account of [client, clientPayout, host1, host2, host3, hostPayout]) {
+    for (let account of [
+      client,
+      clientPayout,
+      host1,
+      host2,
+      host3,
+      hostPayout,
+    ]) {
       await token.mint(account.address, ACCOUNT_STARTING_BALANCE)
     }
 
@@ -599,16 +607,16 @@ describe("Marketplace", function () {
 
     it("rejects withdraw when request not yet timed out", async function () {
       switchAccount(client)
-      await expect(marketplace.withdrawFunds(slot.request, clientPayout.address)).to.be.revertedWith(
-        "Request not yet timed out"
-      )
+      await expect(
+        marketplace.withdrawFunds(slot.request, clientPayout.address)
+      ).to.be.revertedWith("Request not yet timed out")
     })
 
     it("rejects withdraw when wrong account used", async function () {
       await waitUntilCancelled(request)
-      await expect(marketplace.withdrawFunds(slot.request, clientPayout.address)).to.be.revertedWith(
-        "Invalid client address"
-      )
+      await expect(
+        marketplace.withdrawFunds(slot.request, clientPayout.address)
+      ).to.be.revertedWith("Invalid client address")
     })
 
     it("rejects withdraw when in wrong state", async function () {
@@ -623,15 +631,17 @@ describe("Marketplace", function () {
       }
       await waitUntilCancelled(request)
       switchAccount(client)
-      await expect(marketplace.withdrawFunds(slot.request, clientPayout.address)).to.be.revertedWith(
-        "Invalid state"
-      )
+      await expect(
+        marketplace.withdrawFunds(slot.request, clientPayout.address)
+      ).to.be.revertedWith("Invalid state")
     })
 
     it("emits event once request is cancelled", async function () {
       await waitUntilCancelled(request)
       switchAccount(client)
-      await expect(marketplace.withdrawFunds(slot.request, clientPayout.address))
+      await expect(
+        marketplace.withdrawFunds(slot.request, clientPayout.address)
+      )
         .to.emit(marketplace, "RequestCancelled")
         .withArgs(requestId(request))
     })

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -435,9 +435,9 @@ describe("Marketplace", function () {
     it("fails to free slot when slot not filled", async function () {
       slot.index = 5
       let nonExistentId = slotId(slot)
-      await expect(marketplace.freeSlot(nonExistentId, host.address)).to.be.revertedWith(
-        "Slot is free"
-      )
+      await expect(
+        marketplace.freeSlot(nonExistentId, host.address)
+      ).to.be.revertedWith("Slot is free")
     })
 
     it("can only be freed by the host occupying the slot", async function () {
@@ -469,7 +469,6 @@ describe("Marketplace", function () {
       switchAccount(host)
       await token.approve(marketplace.address, request.ask.collateral)
     })
-
 
     it("pays to host payout address when contract has finished and returns collateral to host address", async function () {
       await waitUntilStarted(marketplace, request, proof, token)
@@ -526,9 +525,9 @@ describe("Marketplace", function () {
       await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
       await marketplace.freeSlot(slotId(slot), host.address)
-      await expect(marketplace.freeSlot(slotId(slot), host.address)).to.be.revertedWith(
-        "Already paid"
-      )
+      await expect(
+        marketplace.freeSlot(slotId(slot), host.address)
+      ).to.be.revertedWith("Already paid")
     })
 
     it("cannot be filled again", async function () {

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -211,16 +211,14 @@ describe("Marketplace", function () {
     })
 
     it("emits event when slot is filled", async function () {
-      await expect(
-        marketplace.fillSlot(slot.request, slot.index, proof, host.address)
-      )
+      await expect(marketplace.fillSlot(slot.request, slot.index, proof))
         .to.emit(marketplace, "SlotFilled")
         .withArgs(slot.request, slot.index)
     })
 
     it("allows retrieval of host that filled slot", async function () {
       expect(await marketplace.getHost(slotId(slot))).to.equal(AddressZero)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       expect(await marketplace.getHost(slotId(slot))).to.equal(host.address)
     })
 
@@ -231,7 +229,7 @@ describe("Marketplace", function () {
     })
 
     it("allows retrieval of request of a filled slot", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       let activeSlot = await marketplace.getActiveSlot(slotId(slot))
       expect(activeSlot.request).to.be.request(request)
       expect(activeSlot.slotIndex).to.equal(slot.index)
@@ -239,26 +237,21 @@ describe("Marketplace", function () {
 
     it("is rejected when proof is incorrect", async function () {
       await expect(
-        marketplace.fillSlot(
-          slot.request,
-          slot.index,
-          invalidProof(),
-          host.address
-        )
+        marketplace.fillSlot(slot.request, slot.index, invalidProof())
       ).to.be.revertedWith("Invalid proof")
     })
 
     it("is rejected when slot already filled", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await expect(
-        marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+        marketplace.fillSlot(slot.request, slot.index, proof)
       ).to.be.revertedWith("Slot is not free")
     })
 
     it("is rejected when request is unknown", async function () {
       let unknown = await exampleRequest()
       await expect(
-        marketplace.fillSlot(requestId(unknown), 0, proof, host.address)
+        marketplace.fillSlot(requestId(unknown), 0, proof)
       ).to.be.revertedWith("Unknown request")
     })
 
@@ -270,35 +263,30 @@ describe("Marketplace", function () {
       await waitUntilCancelled(expired)
       switchAccount(host)
       await expect(
-        marketplace.fillSlot(
-          requestId(expired),
-          slot.index,
-          proof,
-          host.address
-        )
+        marketplace.fillSlot(requestId(expired), slot.index, proof)
       ).to.be.revertedWith("Slot is not free")
     })
 
     it("is rejected when request is finished", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, slot.request)
       await expect(
-        marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+        marketplace.fillSlot(slot.request, slot.index, proof)
       ).to.be.revertedWith("Slot is not free")
     })
 
     it("is rejected when request is failed", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFailed(marketplace, request)
       await expect(
-        marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+        marketplace.fillSlot(slot.request, slot.index, proof)
       ).to.be.revertedWith("Slot is not free")
     })
 
     it("is rejected when slot index not in range", async function () {
       const invalid = request.ask.slots
       await expect(
-        marketplace.fillSlot(slot.request, invalid, proof, host.address)
+        marketplace.fillSlot(slot.request, invalid, proof)
       ).to.be.revertedWith("Invalid slot")
     })
 
@@ -310,10 +298,10 @@ describe("Marketplace", function () {
       )
       await token.approve(marketplace.address, price(request) * lastSlot)
       for (let i = 0; i <= lastSlot; i++) {
-        await marketplace.fillSlot(slot.request, i, proof, host.address)
+        await marketplace.fillSlot(slot.request, i, proof)
       }
       await expect(
-        marketplace.fillSlot(slot.request, lastSlot, proof, host.address)
+        marketplace.fillSlot(slot.request, lastSlot, proof)
       ).to.be.revertedWith("Slot is not free")
     })
   })
@@ -330,14 +318,14 @@ describe("Marketplace", function () {
       let insufficient = request.ask.collateral - 1
       await token.approve(marketplace.address, insufficient)
       await expect(
-        marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+        marketplace.fillSlot(slot.request, slot.index, proof)
       ).to.be.revertedWith("ERC20: insufficient allowance")
     })
 
     it("collects only requested collateral and not more", async function () {
       await token.approve(marketplace.address, request.ask.collateral * 2)
       const startBalanace = await token.balanceOf(host.address)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       const endBalance = await token.balanceOf(host.address)
       expect(startBalanace - endBalance).to.eq(request.ask.collateral)
     })
@@ -350,7 +338,7 @@ describe("Marketplace", function () {
       await marketplace.requestStorage(request)
       switchAccount(host)
       await token.approve(marketplace.address, request.ask.collateral)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await advanceTimeForNextBlock(config.proofs.period)
     })
 
@@ -390,14 +378,14 @@ describe("Marketplace", function () {
     })
 
     it("sets the request end time to now + duration", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await expect(
         (await marketplace.requestEnd(requestId(request))).toNumber()
       ).to.be.closeTo(requestTime + request.ask.duration, 1)
     })
 
     it("sets request end time to the past once failed", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFailed(marketplace, request)
       let slot0 = { ...slot, index: request.ask.maxSlotLoss + 1 }
       const now = await currentTime()
@@ -407,7 +395,7 @@ describe("Marketplace", function () {
     })
 
     it("sets request end time to the past once cancelled", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(request)
       await mine()
       const now = await currentTime()
@@ -417,7 +405,7 @@ describe("Marketplace", function () {
     })
 
     it("checks that request end time is in the past once finished", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
       await mine()
       const now = await currentTime()
@@ -447,27 +435,27 @@ describe("Marketplace", function () {
     it("fails to free slot when slot not filled", async function () {
       slot.index = 5
       let nonExistentId = slotId(slot)
-      await expect(marketplace.freeSlot(nonExistentId)).to.be.revertedWith(
+      await expect(marketplace.freeSlot(nonExistentId, host.address)).to.be.revertedWith(
         "Slot is free"
       )
     })
 
     it("can only be freed by the host occupying the slot", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       switchAccount(client)
-      await expect(marketplace.freeSlot(id)).to.be.revertedWith(
+      await expect(marketplace.freeSlot(id, host.address)).to.be.revertedWith(
         "Slot filled by other host"
       )
     })
 
     it("successfully frees slot", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
-      await expect(marketplace.freeSlot(id)).not.to.be.reverted
+      await waitUntilStarted(marketplace, request, proof, token)
+      await expect(marketplace.freeSlot(id, host.address)).not.to.be.reverted
     })
 
     it("emits event once slot is freed", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
-      await expect(await marketplace.freeSlot(id))
+      await waitUntilStarted(marketplace, request, proof, token)
+      await expect(await marketplace.freeSlot(id, host.address))
         .to.emit(marketplace, "SlotFreed")
         .withArgs(slot.request, slot.index)
     })
@@ -482,12 +470,13 @@ describe("Marketplace", function () {
       await token.approve(marketplace.address, request.ask.collateral)
     })
 
+
     it("pays to host payout address when contract has finished and returns collateral to host address", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host2.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
       const startBalanceHostAddr = await token.balanceOf(host.address)
       const startBalancePayoutAddr = await token.balanceOf(host2.address)
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host2.address)
       const endBalanceHostAddr = await token.balanceOf(host.address)
       const endBalancePayoutAddr = await token.balanceOf(host2.address)
       expect(endBalanceHostAddr - startBalanceHostAddr).to.equal(
@@ -506,10 +495,10 @@ describe("Marketplace", function () {
       ).toNumber()
 
       await advanceTimeToForNextBlock(filledAt)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host2.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(request)
       const startBalanceHostAddr = await token.balanceOf(host.address)
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host2.address)
 
       const expectedPartialPayout = (expiresAt - filledAt) * request.ask.reward
       const endBalancePayoutAddr = await token.balanceOf(host2.address)
@@ -523,10 +512,10 @@ describe("Marketplace", function () {
     })
 
     it("does not pay when the contract hasn't ended", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host2.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       const startBalanceHost = await token.balanceOf(host.address)
       const startBalancePayout = await token.balanceOf(host2.address)
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host2.address)
       const endBalanceHost = await token.balanceOf(host.address)
       const endBalancePayout = await token.balanceOf(host2.address)
       expect(endBalanceHost).to.equal(startBalanceHost)
@@ -534,21 +523,20 @@ describe("Marketplace", function () {
     })
 
     it("can only be done once", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
-      await marketplace.freeSlot(slotId(slot))
-      await expect(marketplace.freeSlot(slotId(slot))).to.be.revertedWith(
+      await marketplace.freeSlot(slotId(slot), host.address)
+      await expect(marketplace.freeSlot(slotId(slot), host.address)).to.be.revertedWith(
         "Already paid"
       )
     })
 
     it("cannot be filled again", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
-      await marketplace.freeSlot(slotId(slot))
-      await expect(
-        marketplace.fillSlot(slot.request, slot.index, proof, host.address)
-      ).to.be.reverted
+      await marketplace.freeSlot(slotId(slot), host.address)
+      await expect(marketplace.fillSlot(slot.request, slot.index, proof)).to.be
+        .reverted
     })
   })
 
@@ -568,13 +556,11 @@ describe("Marketplace", function () {
         request.ask.collateral * lastSlot
       )
       for (let i = 0; i < lastSlot; i++) {
-        await marketplace.fillSlot(slot.request, i, proof, host.address)
+        await marketplace.fillSlot(slot.request, i, proof)
       }
 
       await token.approve(marketplace.address, request.ask.collateral)
-      await expect(
-        marketplace.fillSlot(slot.request, lastSlot, proof, host.address)
-      )
+      await expect(marketplace.fillSlot(slot.request, lastSlot, proof))
         .to.emit(marketplace, "RequestFulfilled")
         .withArgs(requestId(request))
     })
@@ -582,7 +568,7 @@ describe("Marketplace", function () {
       const slots = request.ask.slots
       await token.approve(marketplace.address, request.ask.collateral * slots)
       for (let i = 0; i < slots; i++) {
-        await marketplace.fillSlot(slot.request, i, proof, host.address)
+        await marketplace.fillSlot(slot.request, i, proof)
       }
       await expect(await marketplace.requestState(slot.request)).to.equal(
         RequestState.Started
@@ -595,10 +581,10 @@ describe("Marketplace", function () {
         request.ask.collateral * (lastSlot + 1)
       )
       for (let i = 0; i <= lastSlot; i++) {
-        await marketplace.fillSlot(slot.request, i, proof, host.address)
+        await marketplace.fillSlot(slot.request, i, proof)
       }
       await expect(
-        marketplace.fillSlot(slot.request, lastSlot, proof, host.address)
+        marketplace.fillSlot(slot.request, lastSlot, proof)
       ).to.be.revertedWith("Slot is not free")
     })
   })
@@ -634,7 +620,7 @@ describe("Marketplace", function () {
         request.ask.collateral * (lastSlot + 1)
       )
       for (let i = 0; i <= lastSlot; i++) {
-        await marketplace.fillSlot(slot.request, i, proof, host.address)
+        await marketplace.fillSlot(slot.request, i, proof)
       }
       await waitUntilCancelled(request)
       switchAccount(client)
@@ -668,7 +654,7 @@ describe("Marketplace", function () {
       ).toNumber()
 
       await advanceTimeToForNextBlock(filledAt)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(request)
       const expectedPartialHostPayout =
         (expiresAt - filledAt) * request.ask.reward
@@ -711,12 +697,12 @@ describe("Marketplace", function () {
     })
 
     it("changes to 'Started' once all slots are filled", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       expect(await marketplace.requestState(slot.request)).to.equal(Started)
     })
 
     it("changes to 'Failed' once too many slots are freed", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFailed(marketplace, request)
       await mine()
       expect(await marketplace.requestState(slot.request)).to.equal(Failed)
@@ -728,7 +714,7 @@ describe("Marketplace", function () {
         request.ask.collateral * (request.ask.maxSlotLoss + 1)
       )
       for (let i = 0; i <= request.ask.maxSlotLoss; i++) {
-        await marketplace.fillSlot(slot.request, i, proof, host.address)
+        await marketplace.fillSlot(slot.request, i, proof)
       }
       for (let i = 0; i <= request.ask.maxSlotLoss; i++) {
         slot.index = i
@@ -739,16 +725,16 @@ describe("Marketplace", function () {
     })
 
     it("changes to 'Finished' when the request ends", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
       await mine()
       expect(await marketplace.requestState(slot.request)).to.equal(Finished)
     })
 
     it("remains 'Finished' once a slot is paid out", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host.address)
       expect(await marketplace.requestState(slot.request)).to.equal(Finished)
     })
   })
@@ -787,32 +773,32 @@ describe("Marketplace", function () {
     })
 
     it("changes to 'Filled' when slot is filled", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       expect(await marketplace.slotState(slotId(slot))).to.equal(Filled)
     })
 
     it("changes to 'Finished' when request finishes", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, slot.request)
       await mine()
       expect(await marketplace.slotState(slotId(slot))).to.equal(Finished)
     })
 
     it("changes to 'Cancelled' when request is cancelled", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(request)
       await mine()
       expect(await marketplace.slotState(slotId(slot))).to.equal(Cancelled)
     })
 
     it("changes to 'Free' when host frees the slot", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.fillSlot(slot.request, slot.index, proof)
+      await marketplace.freeSlot(slotId(slot), host.address)
       expect(await marketplace.slotState(slotId(slot))).to.equal(Free)
     })
 
     it("changes to 'Free' when too many proofs are missed", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       while ((await marketplace.slotState(slotId(slot))) === Filled) {
         await waitUntilProofIsRequired(slotId(slot))
         const missedPeriod = periodOf(await currentTime())
@@ -824,16 +810,16 @@ describe("Marketplace", function () {
     })
 
     it("changes to 'Failed' when request fails", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilSlotFailed(marketplace, request, slot)
       await mine()
       expect(await marketplace.slotState(slotId(slot))).to.equal(Failed)
     })
 
     it("changes to 'Paid' when host has been paid", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, slot.request)
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host.address)
       expect(await marketplace.slotState(slotId(slot))).to.equal(Paid)
     })
   })
@@ -873,13 +859,13 @@ describe("Marketplace", function () {
 
     it("requires proofs when slot is filled", async function () {
       const id = slotId(slot)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilProofWillBeRequired(id)
     })
 
     it("will not require proofs once cancelled", async function () {
       const id = slotId(slot)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilProofWillBeRequired(id)
       await expect(await marketplace.willProofBeRequired(id)).to.be.true
       await waitUntilCancelled(request)
@@ -889,7 +875,7 @@ describe("Marketplace", function () {
 
     it("does not require proofs once cancelled", async function () {
       const id = slotId(slot)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilProofIsRequired(id)
       await expect(await marketplace.isProofRequired(id)).to.be.true
       await waitUntilCancelled(request)
@@ -899,7 +885,7 @@ describe("Marketplace", function () {
 
     it("does not provide challenges once cancelled", async function () {
       const id = slotId(slot)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilProofIsRequired(id)
       await mine()
       const challenge1 = await marketplace.getChallenge(id)
@@ -912,7 +898,7 @@ describe("Marketplace", function () {
 
     it("does not provide pointer once cancelled", async function () {
       const id = slotId(slot)
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilProofIsRequired(id)
       await mine()
       const challenge1 = await marketplace.getChallenge(id)
@@ -953,7 +939,7 @@ describe("Marketplace", function () {
     }
 
     it("fails to mark proof as missing when cancelled", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(request)
       let missedPeriod = periodOf(await currentTime())
       await expect(
@@ -965,12 +951,7 @@ describe("Marketplace", function () {
       it("reduces collateral when too many proofs are missing", async function () {
         const id = slotId(slot)
         const { slashCriterion, slashPercentage } = config.collateral
-        await marketplace.fillSlot(
-          slot.request,
-          slot.index,
-          proof,
-          host.address
-        )
+        await marketplace.fillSlot(slot.request, slot.index, proof)
         for (let i = 0; i < slashCriterion; i++) {
           await waitUntilProofIsRequired(id)
           let missedPeriod = periodOf(await currentTime())
@@ -995,7 +976,7 @@ describe("Marketplace", function () {
           config.collateral.maxNumberOfSlashes *
           config.collateral.slashPercentage) /
           100
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       while ((await marketplace.slotState(slotId(slot))) === SlotState.Filled) {
         expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.gt(
           minimum
@@ -1018,7 +999,7 @@ describe("Marketplace", function () {
           config.collateral.maxNumberOfSlashes *
           config.collateral.slashPercentage) /
           100
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       let missedProofs = 0
       while ((await marketplace.slotState(slotId(slot))) === SlotState.Filled) {
         expect(await marketplace.getSlotCollateral(slotId(slot))).to.be.gt(
@@ -1071,7 +1052,7 @@ describe("Marketplace", function () {
     it("keeps request in list when request fails", async function () {
       await marketplace.requestStorage(request)
       switchAccount(host)
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFailed(marketplace, request)
       await mine()
       switchAccount(client)
@@ -1081,9 +1062,9 @@ describe("Marketplace", function () {
     it("removes request from list when request finishes", async function () {
       await marketplace.requestStorage(request)
       switchAccount(host)
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host.address)
       switchAccount(client)
       expect(await marketplace.myRequests()).to.deep.equal([])
     })
@@ -1099,10 +1080,10 @@ describe("Marketplace", function () {
     })
 
     it("adds slot to list when filling slot", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       let slot1 = { ...slot, index: slot.index + 1 }
       await token.approve(marketplace.address, request.ask.collateral)
-      await marketplace.fillSlot(slot.request, slot1.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot1.index, proof)
       expect(await marketplace.mySlots()).to.have.members([
         slotId(slot),
         slotId(slot1),
@@ -1110,21 +1091,21 @@ describe("Marketplace", function () {
     })
 
     it("removes slot from list when slot is freed", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       let slot1 = { ...slot, index: slot.index + 1 }
       await token.approve(marketplace.address, request.ask.collateral)
-      await marketplace.fillSlot(slot.request, slot1.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot1.index, proof)
       await token.approve(marketplace.address, request.ask.collateral)
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host.address)
       expect(await marketplace.mySlots()).to.have.members([slotId(slot1)])
     })
 
     it("keeps slots when cancelled", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       let slot1 = { ...slot, index: slot.index + 1 }
 
       await token.approve(marketplace.address, request.ask.collateral)
-      await marketplace.fillSlot(slot.request, slot1.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot1.index, proof)
       await waitUntilCancelled(request)
       await mine()
       expect(await marketplace.mySlots()).to.have.members([
@@ -1134,23 +1115,23 @@ describe("Marketplace", function () {
     })
 
     it("removes slot when finished slot is freed", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilFinished(marketplace, requestId(request))
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host.address)
       expect(await marketplace.mySlots()).to.not.contain(slotId(slot))
     })
 
     it("removes slot when cancelled slot is freed", async function () {
-      await marketplace.fillSlot(slot.request, slot.index, proof, host.address)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(request)
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host.address)
       expect(await marketplace.mySlots()).to.not.contain(slotId(slot))
     })
 
     it("removes slot when failed slot is freed", async function () {
-      await waitUntilStarted(marketplace, request, proof, token, host.address)
+      await waitUntilStarted(marketplace, request, proof, token)
       await waitUntilSlotFailed(marketplace, request, slot)
-      await marketplace.freeSlot(slotId(slot))
+      await marketplace.freeSlot(slotId(slot), host.address)
       expect(await marketplace.mySlots()).to.not.contain(slotId(slot))
     })
   })

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -22,7 +22,13 @@ async function waitUntilStarted(contract, request, proof, token) {
   }
 }
 
-async function waitUntilStarted(contract, request, proof, token, payoutAddress) {
+async function waitUntilStarted(
+  contract,
+  request,
+  proof,
+  token,
+  payoutAddress
+) {
   await token.approve(contract.address, price(request) * request.ask.slots)
 
   for (let i = 0; i < request.ask.slots; i++) {
@@ -66,12 +72,18 @@ async function waitUntilSlotFailed(contract, request, slot) {
  */
 function patchFillSlotOverloads(contract) {
   contract.fillSlot = async (requestId, slotIndex, proof, payoutAddress) => {
-    if(!payoutAddress) {
+    if (!payoutAddress) {
       // calls `fillSlot` overload without payoutAddress
-      const fn = contract["fillSlot(bytes32,uint256,((uint256,uint256),((uint256,uint256),(uint256,uint256)),(uint256,uint256)))"]
+      const fn =
+        contract[
+          "fillSlot(bytes32,uint256,((uint256,uint256),((uint256,uint256),(uint256,uint256)),(uint256,uint256)))"
+        ]
       return await fn(requestId, slotIndex, proof)
     }
-    const fn = contract["fillSlot(bytes32,uint256,((uint256,uint256),((uint256,uint256),(uint256,uint256)),(uint256,uint256)),address)"]
+    const fn =
+      contract[
+        "fillSlot(bytes32,uint256,((uint256,uint256),((uint256,uint256),(uint256,uint256)),(uint256,uint256)),address)"
+      ]
     return await fn(requestId, slotIndex, proof, payoutAddress)
   }
 }

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -57,12 +57,18 @@ async function waitUntilSlotFailed(contract, request, slot) {
   }
 }
 
+/**
+ * Patch the Marketplace contract object, adding a `fillSlot` function that
+ * accepts an optional `payoutAddress` parameter, to call the corresponding
+ * `fillSlot` overload in the Marketplace contract. Solidity supports function
+ * overloading while javascript does not. This is is a workaround for that
+ * discrepancy.
+ */
 function patchFillSlotOverloads(contract) {
   contract.fillSlot = async (requestId, slotIndex, proof, payoutAddress) => {
     if(!payoutAddress) {
       // calls `fillSlot` overload without payoutAddress
       const fn = contract["fillSlot(bytes32,uint256,((uint256,uint256),((uint256,uint256),(uint256,uint256)),(uint256,uint256)))"]
-
       return await fn(requestId, slotIndex, proof)
     }
     const fn = contract["fillSlot(bytes32,uint256,((uint256,uint256),((uint256,uint256),(uint256,uint256)),(uint256,uint256)),address)"]

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -49,10 +49,24 @@ async function waitUntilSlotFailed(contract, request, slot) {
   }
 }
 
+function patchFreeSlotOverloads(contract) {
+  contract.freeSlot = async (slotId, rewardRecipient, collateralRecipient) => {
+    if (!collateralRecipient) {
+      // calls `freeSlot` overload without collateralRecipient
+      const fn = contract["freeSlot(bytes32,address)"]
+
+      return await fn(slotId, rewardRecipient)
+    }
+    const fn = contract["freeSlot(bytes32,address,address)"]
+    return await fn(slotId, rewardRecipient, collateralRecipient)
+  }
+}
+
 module.exports = {
   waitUntilCancelled,
   waitUntilStarted,
   waitUntilFinished,
   waitUntilFailed,
   waitUntilSlotFailed,
+  patchFreeSlotOverloads,
 }

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -18,13 +18,12 @@ async function waitUntilStarted(
   contract,
   request,
   proof,
-  token,
-  payoutAddress
+  token
 ) {
   await token.approve(contract.address, price(request) * request.ask.slots)
 
   for (let i = 0; i < request.ask.slots; i++) {
-    await contract.fillSlot(requestId(request), i, proof, payoutAddress)
+    await contract.fillSlot(requestId(request), i, proof)
   }
 }
 

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -14,12 +14,7 @@ async function waitUntilCancelled(request) {
   await advanceTimeToForNextBlock((await currentTime()) + request.expiry + 1)
 }
 
-async function waitUntilStarted(
-  contract,
-  request,
-  proof,
-  token
-) {
+async function waitUntilStarted(contract, request, proof, token) {
   await token.approve(contract.address, price(request) * request.ask.slots)
 
   for (let i = 0; i < request.ask.slots; i++) {


### PR DESCRIPTION
Closes: #71.

Adds an optional `payoutAddress` to the `fillSlot` function, tracking this address in the `Slot`. When SPs are paid out after request completion/cancellation, reward payouts are paid to the `payoutAddress` (if supplied), while collateral is returned to the SP's address. If the `payoutAddress` is not supplied in `fillSlot`, payouts are made to the SP's address (as it was before this PR).