### PR TITLE
chore(certora): add invariant that totalSent is <= totalReceived

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           java-package: 'jre'
 
       - name: Install Certora CLI
-        run: pip3 install certora-cli==7.10.2
+        run: pip3 install certora-cli==7.17.2
 
       - name: Install Solidity
         run: |

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -253,6 +253,22 @@ invariant cancelledSlotAlwaysHasCancelledRequest(env e, Marketplace.SlotId slotI
     currentContract.slotState(e, slotId) == Marketplace.SlotState.Cancelled =>
         currentContract.requestState(e, slotIdToRequestId[slotId]) == Marketplace.RequestState.Cancelled;
 
+// STATUS - in progress (fails on constructor state due to a strange behaviour in the tool)
+// _marketplaceTotals.received - _marketplaceTotals.sent == tokenBalanceOfContract
+// https://prover.certora.com/output/3106/4e6cac8055ac45bb92840e14d9b095eb/?anonymousKey=655a42ca6306a023db78914d5a188d8ec2882771
+invariant totalSentIsLessThanOrEqualTotalReceived()
+    totalReceived - totalSent <= to_mathint(Token.balanceOf(currentContract))
+    {
+        preserved fillSlot(MarketplaceHarness.RequestId requestId, uint256 slotIndex, MarketplaceHarness.Groth16Proof proof) with (env e2) {
+            require e2.msg.sender != currentContract;
+            requireInvariant totalSupplyIsSumOfBalances();
+        }
+        preserved requestStorage(MarketplaceHarness.Request request) with (env e3) {
+            require e3.msg.sender != currentContract;
+            requireInvariant totalSupplyIsSumOfBalances();
+        }
+    }
+
 /*--------------------------------------------
 |                 Properties                 |
 --------------------------------------------*/


### PR DESCRIPTION
This commit adds an invariant that verifies `marketplaceTotals.sent <= marketplceTotals.received`.

The invariant relies on the `Token.totalSupply()` which has previously been verified to be the sum of all balances.

The invariant uses `<=` as there could be donations sent to the marketplace.

Closes #132

**This PR depends on #146**