### PR TITLE
chore(certora): add invariant that proofs cant be missing when in period

### DIFF
--- a/certora/harness/MarketplaceHarness.sol
+++ b/certora/harness/MarketplaceHarness.sol
@@ -14,5 +14,9 @@ contract MarketplaceHarness is Marketplace {
     function requestContext(RequestId requestId) public returns (Marketplace.RequestContext memory) {
         return _requestContexts[requestId];
     }
+
+    function publicPeriodEnd(Period period) public view returns (uint256) {
+        return _periodEnd(period);
+    }
 }
 


### PR DESCRIPTION
This invariant verifies that any given proof cannot be marked as missing if the slot period has not passed yet.

**This PR sits on top of #147**
