### PR TITLE
chore(certora): slot's missed periods count should be equal to the count of slot's missing periods set to true

### DIFF
--- a/contracts/Proofs.sol
+++ b/contracts/Proofs.sol
@@ -203,6 +203,7 @@ abstract contract Proofs is Periods {
    * @dev Reverts when:
    *    - missedPeriod has not ended yet ended
    *    - missing proof was time-barred
+   *    - proof was submitted
    *    - proof was not required for missedPeriod period
    *    - proof was already marked as missing
    */


### PR DESCRIPTION
This invariant makes sure that `_missed[slotId]` is equal to the count of `_missing[slotId]` periods set to `true`.

Closes #133 