### PR TITLE
set MarketplaceHarness as parametric_contract config value

### DIFF
--- a/certora/confs/Marketplace.conf
+++ b/certora/confs/Marketplace.conf
@@ -5,12 +5,12 @@
         "contracts/Groth16Verifier.sol",
         "certora/helpers/ERC20A.sol",
     ],
-    "parametric_contracts": ["Marketplace"],
+    "parametric_contracts": ["MarketplaceHarness"],
     "link" : [
-        "Marketplace:_token=ERC20A",
-        "Marketplace:_verifier=Groth16Verifier"
+        "MarketplaceHarness:_token=ERC20A",
+        "MarketplaceHarness:_verifier=Groth16Verifier"
     ],
-    "msg": "Verifying Marketplace",
+    "msg": "Verifying MarketplaceHarness",
     "rule_sanity": "basic",
     "verify": "MarketplaceHarness:certora/specs/Marketplace.spec",
     "optimistic_loop": true,


### PR DESCRIPTION
Fixes the certora config to use the MarketplaceHarness as parameteric config value