### PR TITLE
Make certora rules pass again

### DIFF
--- a/certora/harness/MarketplaceHarness.sol
+++ b/certora/harness/MarketplaceHarness.sol
@@ -6,13 +6,17 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IGroth16Verifier} from "../../contracts/Groth16.sol";
 import {MarketplaceConfig} from "../../contracts/Configuration.sol";
 import {Marketplace} from "../../contracts/Marketplace.sol";
-import {RequestId} from "../../contracts/Requests.sol";
+import {RequestId, SlotId} from "../../contracts/Requests.sol";
 
 contract MarketplaceHarness is Marketplace {
     constructor(MarketplaceConfig memory config, IERC20 token, IGroth16Verifier verifier) Marketplace(config, token, verifier) {}
 
     function requestContext(RequestId requestId) public returns (Marketplace.RequestContext memory) {
         return _requestContexts[requestId];
+    }
+
+    function slots(SlotId slotId) public returns (Marketplace.Slot memory) {
+        return _slots[slotId];
     }
 
     function publicPeriodEnd(Period period) public view returns (uint256) {

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -170,6 +170,18 @@ invariant finishedSlotAlwaysHasFinishedRequest(env e, Marketplace.SlotId slotId)
     currentContract.slotState(e, slotId) == Marketplace.SlotState.Finished =>
         currentContract.requestState(e, currentContract.slots(e, slotId).requestId) == Marketplace.RequestState.Finished;
 
+// STATUS - verified
+// paid slot always has finished or cancelled request
+// https://prover.certora.com/output/6199/6217a927ff2c43bea1124f6ae54a78fb?anonymousKey=d5e09d0d12658fd6b5f298fc04cea88da892c62d
+invariant paidSlotAlwaysHasFinishedOrCancelledRequest(env e, Marketplace.SlotId slotId)
+     currentContract.slotState(e, slotId) == Marketplace.SlotState.Paid =>
+         currentContract.requestState(e, currentContract.slots(e, slotId).requestId) == Marketplace.RequestState.Finished || currentContract.requestState(e, currentContract.slots(e, slotId).requestId) == Marketplace.RequestState.Cancelled
+    { preserved {
+        // ensures we start with a paid slot
+        require currentContract.slotState(e, slotId) == Marketplace.SlotState.Paid;
+      }
+    }
+
 /*--------------------------------------------
 |                 Properties                 |
 --------------------------------------------*/

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -136,7 +136,7 @@ invariant totalSupplyIsSumOfBalances()
     to_mathint(Token.totalSupply()) == sumOfBalances;
 
 invariant requestStartedWhenSlotsFilled(env e, Marketplace.RequestId requestId, Marketplace.SlotId slotId)
-    to_mathint(currentContract.requestContext(e, requestId).slotsFilled) == to_mathint(currentContract.getRequest(e, requestId).ask.slots) => currentContract.requestState(e, requestId) == Marketplace.RequestState.Started;
+    currentContract.requestState(e, requestId) == Marketplace.RequestState.Started => to_mathint(currentContract.getRequest(e, requestId).ask.slots) - to_mathint(currentContract.requestContext(e, requestId).slotsFilled) <= to_mathint(currentContract.getRequest(e, requestId).ask.maxSlotLoss);
 
 // STATUS - verified
 // https://prover.certora.com/output/6199/6e2383ea040347eabeeb1008bc257ae6?anonymousKey=e1a6a00310a44ed264b1f98b03fa29273e68fca9

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -163,6 +163,13 @@ invariant failedRequestAlwaysEnded(env e, Marketplace.RequestId requestId)
     currentContract.requestState(e, requestId) == Marketplace.RequestState.Failed =>
         currentContract.requestContext(e, requestId).endsAt < lastBlockTimestampGhost;
 
+// STATUS - verified
+// finished slot always has finished request
+// https://prover.certora.com/output/6199/3371ee4f80354ac9b05b1c84c53b6154?anonymousKey=eab83785acb61ccd31ed0c9d5a2e9e2b24099156
+invariant finishedSlotAlwaysHasFinishedRequest(env e, Marketplace.SlotId slotId)
+    currentContract.slotState(e, slotId) == Marketplace.SlotState.Finished =>
+        currentContract.requestState(e, currentContract.slots(e, slotId).requestId) == Marketplace.RequestState.Finished;
+
 /*--------------------------------------------
 |                 Properties                 |
 --------------------------------------------*/

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -120,12 +120,14 @@ function canStartRequest(method f) returns bool {
 }
 
 function canFinishRequest(method f) returns bool {
-    return f.selector == sig:freeSlot(Marketplace.SlotId, address, address).selector;
+    return f.selector == sig:freeSlot(Marketplace.SlotId, address, address).selector ||
+        f.selector == sig:freeSlot(Marketplace.SlotId).selector;
 }
 
 function canFailRequest(method f) returns bool {
     return f.selector == sig:markProofAsMissing(Marketplace.SlotId, Periods.Period).selector ||
-        f.selector == sig:freeSlot(Marketplace.SlotId, address, address).selector;
+        f.selector == sig:freeSlot(Marketplace.SlotId, address, address).selector ||
+        f.selector == sig:freeSlot(Marketplace.SlotId).selector;
 }
 
 /*--------------------------------------------
@@ -261,6 +263,9 @@ rule functionsCausingRequestStateChanges(env e, method f) {
 
     // RequestState.New -> RequestState.Started
     assert requestStateBefore == Marketplace.RequestState.New && requestStateAfter == Marketplace.RequestState.Started => canStartRequest(f);
+
+    // RequestState.New -> RequestState.Cancelled
+    assert requestStateBefore == Marketplace.RequestState.New && requestStateAfter == Marketplace.RequestState.Cancelled => canCancelRequest(f);
 
     // RequestState.Started -> RequestState.Finished
     assert requestStateBefore == Marketplace.RequestState.Started && requestStateAfter == Marketplace.RequestState.Finished => canFinishRequest(f);

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -222,6 +222,21 @@ rule totalSentCannotDecrease(env e, method f) {
     assert total_after >= total_before;
 }
 
+rule slotIsFailedOrFreeIfRequestHasFailed(env e, method f) {
+    calldataarg args;
+    Marketplace.SlotId slotId;
+
+    requireInvariant paidSlotAlwaysHasFinishedOrCancelledRequest(e, slotId);
+
+    require currentContract.requestState(e, currentContract.slots(e, slotId).requestId) != Marketplace.RequestState.Failed;
+    f(e, args);
+    require currentContract.requestState(e, currentContract.slots(e, slotId).requestId) == Marketplace.RequestState.Failed;
+
+    assert currentContract.slotState(e, slotId) == Marketplace.SlotState.Failed ||
+        currentContract.slotState(e, slotId) == Marketplace.SlotState.Free;
+}
+
+
 rule allowedRequestStateChanges(env e, method f) {
     calldataarg args;
     Marketplace.RequestId requestId;

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -182,6 +182,13 @@ invariant paidSlotAlwaysHasFinishedOrCancelledRequest(env e, Marketplace.SlotId 
       }
     }
 
+// STATUS - verified
+// cancelled slot always belongs to cancelled request
+// https://prover.certora.com/output/6199/80d5dc73d406436db166071e277283f1?anonymousKey=d5d175960dc40f72e22ba8e31c6904a488277e57
+invariant cancelledSlotAlwaysHasCancelledRequest(env e, Marketplace.SlotId slotId)
+    currentContract.slotState(e, slotId) == Marketplace.SlotState.Cancelled =>
+        currentContract.requestState(e, currentContract.slots(e, slotId).requestId) == Marketplace.RequestState.Cancelled;
+
 /*--------------------------------------------
 |                 Properties                 |
 --------------------------------------------*/

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -149,6 +149,13 @@ invariant slotMissedShouldBeEqualToNumberOfMissedPeriods(env e, Marketplace.Slot
 invariant cantBeMissedIfInPeriod(MarketplaceHarness.SlotId slotId, Periods.Period period)
     lastBlockTimestampGhost <= publicPeriodEnd(period) => !_missingMirror[slotId][period];
 
+// STATUS - verified
+// cancelled request is always expired
+// https://prover.certora.com/output/6199/36b12b897f3941faa00fb4ab6871be8e?anonymousKey=de98a02041b841fb2fa67af4222f29fac258249f
+invariant cancelledRequestAlwaysExpired(env e, Marketplace.RequestId requestId)
+    currentContract.requestState(e, requestId) == Marketplace.RequestState.Cancelled =>
+        currentContract.requestExpiry(e, requestId) < lastBlockTimestampGhost;
+
 /*--------------------------------------------
 |                 Properties                 |
 --------------------------------------------*/

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -156,6 +156,13 @@ invariant cancelledRequestAlwaysExpired(env e, Marketplace.RequestId requestId)
     currentContract.requestState(e, requestId) == Marketplace.RequestState.Cancelled =>
         currentContract.requestExpiry(e, requestId) < lastBlockTimestampGhost;
 
+// STATUS - verified
+// failed request is always ended
+// https://prover.certora.com/output/6199/902ffe4a83a9438e9860655446b46a74?anonymousKey=47b344024bbfe84a649bd1de44d7d243ce8dbc21
+invariant failedRequestAlwaysEnded(env e, Marketplace.RequestId requestId)
+    currentContract.requestState(e, requestId) == Marketplace.RequestState.Failed =>
+        currentContract.requestContext(e, requestId).endsAt < lastBlockTimestampGhost;
+
 /*--------------------------------------------
 |                 Properties                 |
 --------------------------------------------*/

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -468,7 +468,8 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
     ) {
       return RequestState.Cancelled;
     } else if (
-      context.state == RequestState.Started && block.timestamp > context.endsAt
+      (context.state == RequestState.Started ||
+        context.state == RequestState.New) && block.timestamp > context.endsAt
     ) {
       return RequestState.Finished;
     } else {


### PR DESCRIPTION
We've had a bug in our certora configuration which resulted in may of our rules to pass, which are actually failing, now that the configuration has been updated.

This PR introduces a bunch of commits that in aggregate fix the broken rules again.

Closes #161