### PR TITLE
fix(Marketplace): ensure requests include ask with sufficient slots

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -95,6 +95,7 @@ contract Marketplace is Proofs, StateRetrieval, Endian {
       request.expiry > 0 && request.expiry < request.ask.duration,
       "Expiry not in range"
     );
+    require(request.ask.slots > 0, "Insufficient slots");
     require(
       request.ask.maxSlotLoss <= request.ask.slots,
       "maxSlotLoss exceeds slots"

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -211,6 +211,13 @@ describe("Marketplace", function () {
       )
     })
 
+    it("is rejected with insufficient slots ", async function () {
+      request.ask.slots = 0
+      await expect(marketplace.requestStorage(request)).to.be.revertedWith(
+        "Insufficient slots"
+      )
+    })
+
     it("is rejected when maxSlotLoss exceeds slots", async function () {
       request.ask.maxSlotLoss = request.ask.slots + 1
       await expect(marketplace.requestStorage(request)).to.be.revertedWith(


### PR DESCRIPTION
There is a missing check in `requestStorage()` on whether the `Request` contains an `Ask` where its `slots` is `> 0`.

This allows for making storage request without slots. Not harmful but not a valid state of the system either.

This commit adds that check and a test with batteries included.