### PR TITLE
refactor(certora): use ghost variables for `requestContext` and `slots`

### DIFF
--- a/certora/harness/MarketplaceHarness.sol
+++ b/certora/harness/MarketplaceHarness.sol
@@ -11,14 +11,6 @@ import {RequestId, SlotId} from "../../contracts/Requests.sol";
 contract MarketplaceHarness is Marketplace {
     constructor(MarketplaceConfig memory config, IERC20 token, IGroth16Verifier verifier) Marketplace(config, token, verifier) {}
 
-    function requestContext(RequestId requestId) public returns (Marketplace.RequestContext memory) {
-        return _requestContexts[requestId];
-    }
-
-    function slots(SlotId slotId) public returns (Marketplace.Slot memory) {
-        return _slots[slotId];
-    }
-
     function publicPeriodEnd(Period period) public view returns (uint256) {
         return _periodEnd(period);
     }


### PR DESCRIPTION
Instead of having additional harness code in `MarketplaceHarness` to access fields in `requestContext` and `slots` objects, this introduces dedicated ghost variables that keep track of the field changes and let us read the values from there.

Prover run: https://prover.certora.com/output/6199/8343693dfc3f4ca38435f5aa10fa2345?anonymousKey=db5eaee6c688651132d1671919fb73544affa269

Closes #165