### PR TITLE
chore(certora): verify possible slot state transitions

### DIFF
--- a/certora/harness/MarketplaceHarness.sol
+++ b/certora/harness/MarketplaceHarness.sol
@@ -7,12 +7,22 @@ import {IGroth16Verifier} from "../../contracts/Groth16.sol";
 import {MarketplaceConfig} from "../../contracts/Configuration.sol";
 import {Marketplace} from "../../contracts/Marketplace.sol";
 import {RequestId, SlotId} from "../../contracts/Requests.sol";
+import {Requests} from "../../contracts/Requests.sol";
 
 contract MarketplaceHarness is Marketplace {
-    constructor(MarketplaceConfig memory config, IERC20 token, IGroth16Verifier verifier) Marketplace(config, token, verifier) {}
+    constructor(MarketplaceConfig memory config, IERC20 token, IGroth16Verifier verifier)
+        Marketplace(config, token, verifier)
+    {}
 
     function publicPeriodEnd(Period period) public view returns (uint256) {
         return _periodEnd(period);
     }
-}
 
+    function slots(SlotId slotId) public view returns (Slot memory) {
+        return _slots[slotId];
+    }
+
+    function generateSlotId(RequestId requestId, uint256 slotIndex) public pure returns (SlotId) {
+        return Requests.slotId(requestId, slotIndex);
+    }
+}


### PR DESCRIPTION
This PR adds a rule to check the possible slot transitions saved in storage and adss an helper function to check the consistency of the slot attributes. 