### PR TITLE
feat(slot-reservations): Allow slots to be reserved

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -7,11 +7,12 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "./Configuration.sol";
 import "./Requests.sol";
 import "./Proofs.sol";
+import "./SlotReservations.sol";
 import "./StateRetrieval.sol";
 import "./Endian.sol";
 import "./Groth16.sol";
 
-contract Marketplace is Proofs, StateRetrieval, Endian {
+contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   using EnumerableSet for EnumerableSet.Bytes32Set;
   using Requests for Request;
 

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./Requests.sol";
+
+contract SlotReservations {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  mapping(SlotId => EnumerableSet.AddressSet) private _reservations;
+
+  uint8 private constant _MAX_RESERVATIONS = 3;
+
+  function reserveSlot(SlotId slotId, address host) public returns (bool) {
+    require(canReserveSlot(slotId, host), "Reservation not allowed");
+    // returns false if set already contains address
+    return _reservations[slotId].add(host);
+  }
+
+  function canReserveSlot(
+    SlotId slotId,
+    address host
+  ) public view returns (bool) {
+    return
+      // TODO: add in check for address inside of expanding window
+      (_reservations[slotId].length() < _MAX_RESERVATIONS) &&
+      (!_reservations[slotId].contains(host));
+  }
+}

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -7,20 +7,19 @@ import "./Requests.sol";
 contract SlotReservations {
   using EnumerableSet for EnumerableSet.AddressSet;
 
-  mapping(SlotId => EnumerableSet.AddressSet) private _reservations;
+  mapping(SlotId => EnumerableSet.AddressSet) internal _reservations;
 
   uint8 private constant _MAX_RESERVATIONS = 3;
 
-  function reserveSlot(SlotId slotId, address host) public returns (bool) {
-    require(canReserveSlot(slotId, host), "Reservation not allowed");
+  function reserveSlot(SlotId slotId) public returns (bool) {
+    address host = msg.sender;
+    require(canReserveSlot(slotId), "Reservation not allowed");
     // returns false if set already contains address
     return _reservations[slotId].add(host);
   }
 
-  function canReserveSlot(
-    SlotId slotId,
-    address host
-  ) public view returns (bool) {
+  function canReserveSlot(SlotId slotId) public view returns (bool) {
+    address host = msg.sender;
     return
       // TODO: add in check for address inside of expanding window
       (_reservations[slotId].length() < _MAX_RESERVATIONS) &&

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -11,11 +11,10 @@ contract SlotReservations {
 
   uint8 private constant _MAX_RESERVATIONS = 3;
 
-  function reserveSlot(SlotId slotId) public returns (bool) {
+  function reserveSlot(SlotId slotId) public {
     address host = msg.sender;
     require(canReserveSlot(slotId), "Reservation not allowed");
-    // returns false if set already contains address
-    return _reservations[slotId].add(host);
+    _reservations[slotId].add(host);
   }
 
   function canReserveSlot(SlotId slotId) public view returns (bool) {

--- a/contracts/TestSlotReservations.sol
+++ b/contracts/TestSlotReservations.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "./SlotReservations.sol";
+
+contract TestSlotReservations is SlotReservations {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  function contains(SlotId slotId, address host) public view returns (bool) {
+    return _reservations[slotId].contains(host);
+  }
+
+  function length(SlotId slotId) public view returns (uint256) {
+    return _reservations[slotId].length();
+  }
+}

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -1,0 +1,73 @@
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+const { exampleRequest, exampleAddress } = require("./examples")
+const { requestId, slotId } = require("./ids")
+
+describe("SlotReservations", function () {
+  let reservations
+  let provider, address1, address2, address3
+  let request
+  let slot
+
+  beforeEach(async function () {
+    let SlotReservations = await ethers.getContractFactory("SlotReservations")
+    reservations = await SlotReservations.deploy()
+
+    provider = exampleAddress()
+    address1 = exampleAddress()
+    address2 = exampleAddress()
+    address3 = exampleAddress()
+
+    request = await exampleRequest()
+    request.client = exampleAddress()
+
+    slot = {
+      request: requestId(request),
+      index: request.ask.slots / 2,
+    }
+  })
+
+  it("allows a slot to be reserved", async function () {
+    let reserved = await reservations.callStatic.reserveSlot(
+      slotId(slot),
+      provider
+    )
+    expect(reserved).to.be.true
+  })
+
+  it("reports a slot can be reserved", async function () {
+    expect(await reservations.canReserveSlot(slotId(slot), provider)).to.be.true
+  })
+
+  it("cannot reserve a slot more than once", async function () {
+    let id = slotId(slot)
+    await reservations.reserveSlot(id, provider)
+    await expect(reservations.reserveSlot(id, provider)).to.be.revertedWith(
+      "Reservation not allowed"
+    )
+  })
+
+  it("reports a slot cannot be reserved if already reserved", async function () {
+    let id = slotId(slot)
+    await reservations.reserveSlot(id, provider)
+    expect(await reservations.canReserveSlot(id, provider)).to.be.false
+  })
+
+  it("cannot reserve a slot if reservations are at capacity", async function () {
+    let id = slotId(slot)
+    await reservations.reserveSlot(id, address1)
+    await reservations.reserveSlot(id, address2)
+    await reservations.reserveSlot(id, address3)
+    await expect(reservations.reserveSlot(id, provider)).to.be.revertedWith(
+      "Reservation not allowed"
+    )
+  })
+
+  it("reports a slot cannot be reserved if reservations are at capacity", async function () {
+    let id = slotId(slot)
+    await reservations.reserveSlot(id, address1)
+    await reservations.reserveSlot(id, address2)
+    await reservations.reserveSlot(id, address3)
+    expect(await reservations.canReserveSlot(id, provider)).to.be.false
+  })
+})

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -8,6 +8,7 @@ describe("SlotReservations", function () {
   let provider, address1, address2, address3
   let request
   let slot
+  let id // can't use slotId because it'll shadow the function slotId
 
   beforeEach(async function () {
     let SlotReservations = await ethers.getContractFactory(
@@ -22,6 +23,8 @@ describe("SlotReservations", function () {
       request: requestId(request),
       index: request.ask.slots / 2,
     }
+
+    id = slotId(slot)
   })
 
   function switchAccount(account) {
@@ -29,13 +32,10 @@ describe("SlotReservations", function () {
   }
 
   it("allows a slot to be reserved", async function () {
-    let id = slotId(slot)
-    let reserved = await reservations.callStatic.reserveSlot(id)
-    expect(reserved).to.be.true
+    expect(reservations.reserveSlot(id)).to.not.be.reverted
   })
 
   it("contains the correct addresses after reservation", async function () {
-    let id = slotId(slot)
     await reservations.reserveSlot(id)
     expect(await reservations.contains(id, provider.address)).to.be.true
 
@@ -45,7 +45,6 @@ describe("SlotReservations", function () {
   })
 
   it("has the correct number of addresses after reservation", async function () {
-    let id = slotId(slot)
     await reservations.reserveSlot(id)
     expect(await reservations.length(id)).to.equal(1)
 
@@ -59,7 +58,6 @@ describe("SlotReservations", function () {
   })
 
   it("cannot reserve a slot more than once", async function () {
-    let id = slotId(slot)
     await reservations.reserveSlot(id)
     await expect(reservations.reserveSlot(id)).to.be.revertedWith(
       "Reservation not allowed"
@@ -68,13 +66,11 @@ describe("SlotReservations", function () {
   })
 
   it("reports a slot cannot be reserved if already reserved", async function () {
-    let id = slotId(slot)
     await reservations.reserveSlot(id)
     expect(await reservations.canReserveSlot(id)).to.be.false
   })
 
   it("cannot reserve a slot if reservations are at capacity", async function () {
-    let id = slotId(slot)
     switchAccount(address1)
     await reservations.reserveSlot(id)
     switchAccount(address2)
@@ -90,7 +86,6 @@ describe("SlotReservations", function () {
   })
 
   it("reports a slot cannot be reserved if reservations are at capacity", async function () {
-    let id = slotId(slot)
     switchAccount(address1)
     await reservations.reserveSlot(id)
     switchAccount(address2)

--- a/test/examples.js
+++ b/test/examples.js
@@ -51,12 +51,9 @@ const invalidProof = () => ({
   c: { x: 0, y: 0 },
 })
 
-const exampleAddress = () => hexlify(randomBytes(20))
-
 module.exports = {
   exampleConfiguration,
   exampleRequest,
   exampleProof,
   invalidProof,
-  exampleAddress,
 }

--- a/test/examples.js
+++ b/test/examples.js
@@ -51,9 +51,12 @@ const invalidProof = () => ({
   c: { x: 0, y: 0 },
 })
 
+const exampleAddress = () => hexlify(randomBytes(20))
+
 module.exports = {
   exampleConfiguration,
   exampleRequest,
   exampleProof,
   invalidProof,
+  exampleAddress,
 }


### PR DESCRIPTION
Closes #175. 

These functions are not called yet. They are being implemented as part of a [longer list of tasks for slot reservations](https://github.com/codex-storage/codex-pm/issues/45) to prevent PRs from being too large.

Allows reservation of slots, without an implementation of the expanding window.

- Add a function called `reserveSlot(address, SlotId)`, that allows three unique addresses per slot to be reserved. 
  - Revert if reservations full or if provider address already reserved slot
  - Use `mapping(SlotId => EnumerableSet.AddressSet)`
- Add `canReserveSlot(address, SlotId)`
  - Return `true` if set of reservations is less than 3 and the set doesn't already contain the address
  - Return `true` otherwise (for now, later add in logic for checking the address is inside the expanding window)
  - Call `canReserveSlot` from `reserveSlot` as a `require` or invariant