### PR TITLE
feat(slot-reservations): Allow slots to be reserved

### DIFF
--- a/contracts/Configuration.sol
+++ b/contracts/Configuration.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 struct MarketplaceConfig {
   CollateralConfig collateral;
   ProofConfig proofs;
+  SlotReservationsConfig reservations;
 }
 
 struct CollateralConfig {
@@ -28,4 +29,9 @@ struct ProofConfig {
   // periods. For each period increase, move the pointer `pointerProduct`
   // blocks. Should be a prime number to ensure there are no cycles.
   uint8 downtimeProduct;
+}
+
+struct SlotReservationsConfig {
+  // Number of allowed reservations per slot
+  uint8 maxReservations;
 }

--- a/contracts/FuzzMarketplace.sol
+++ b/contracts/FuzzMarketplace.sol
@@ -10,7 +10,8 @@ contract FuzzMarketplace is Marketplace {
     Marketplace(
       MarketplaceConfig(
         CollateralConfig(10, 5, 3, 10),
-        ProofConfig(10, 5, 64, "", 67)
+        ProofConfig(10, 5, 64, "", 67),
+        SlotReservationsConfig(20)
       ),
       new TestToken(),
       new TestVerifier()

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -7,11 +7,12 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "./Configuration.sol";
 import "./Requests.sol";
 import "./Proofs.sol";
+import "./SlotReservations.sol";
 import "./StateRetrieval.sol";
 import "./Endian.sol";
 import "./Groth16.sol";
 
-contract Marketplace is Proofs, StateRetrieval, Endian {
+contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   using EnumerableSet for EnumerableSet.Bytes32Set;
   using Requests for Request;
 

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -59,7 +59,10 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     MarketplaceConfig memory configuration,
     IERC20 token_,
     IGroth16Verifier verifier
-  ) Proofs(configuration.proofs, verifier) {
+  )
+    SlotReservations(configuration.reservations)
+    Proofs(configuration.proofs, verifier)
+  {
     _token = token_;
 
     require(

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "./Requests.sol";
+
+contract SlotReservations {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  mapping(SlotId => EnumerableSet.AddressSet) private _reservations;
+
+  uint8 private constant _MAX_RESERVATIONS = 3;
+
+  function reserveSlot(SlotId slotId, address host) public returns (bool) {
+    require(canReserveSlot(slotId, host), "Reservation not allowed");
+    // returns false if set already contains address
+    return _reservations[slotId].add(host);
+  }
+
+  function canReserveSlot(
+    SlotId slotId,
+    address host
+  ) public view returns (bool) {
+    return
+      // TODO: add in check for address inside of expanding window
+      (_reservations[slotId].length() < _MAX_RESERVATIONS) &&
+      (!_reservations[slotId].contains(host));
+  }
+}

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -7,20 +7,19 @@ import "./Requests.sol";
 contract SlotReservations {
   using EnumerableSet for EnumerableSet.AddressSet;
 
-  mapping(SlotId => EnumerableSet.AddressSet) private _reservations;
+  mapping(SlotId => EnumerableSet.AddressSet) internal _reservations;
 
   uint8 private constant _MAX_RESERVATIONS = 3;
 
-  function reserveSlot(SlotId slotId, address host) public returns (bool) {
-    require(canReserveSlot(slotId, host), "Reservation not allowed");
+  function reserveSlot(SlotId slotId) public returns (bool) {
+    address host = msg.sender;
+    require(canReserveSlot(slotId), "Reservation not allowed");
     // returns false if set already contains address
     return _reservations[slotId].add(host);
   }
 
-  function canReserveSlot(
-    SlotId slotId,
-    address host
-  ) public view returns (bool) {
+  function canReserveSlot(SlotId slotId) public view returns (bool) {
+    address host = msg.sender;
     return
       // TODO: add in check for address inside of expanding window
       (_reservations[slotId].length() < _MAX_RESERVATIONS) &&

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -11,14 +11,16 @@ contract SlotReservations {
 
   uint8 private constant _MAX_RESERVATIONS = 3;
 
-  function reserveSlot(SlotId slotId) public {
-    address host = msg.sender;
-    require(canReserveSlot(slotId), "Reservation not allowed");
-    _reservations[slotId].add(host);
+  function reserveSlot(RequestId requestId, uint256 slotIndex) public {
+    require(canReserveSlot(requestId, slotIndex), "Reservation not allowed");
+
+    SlotId slotId = Requests.slotId(requestId, slotIndex);
+    _reservations[slotId].add(msg.sender);
   }
 
-  function canReserveSlot(SlotId slotId) public view returns (bool) {
+  function canReserveSlot(RequestId requestId, uint256 slotIndex) public view returns (bool) {
     address host = msg.sender;
+    SlotId slotId = Requests.slotId(requestId, slotIndex);
     return
       // TODO: add in check for address inside of expanding window
       (_reservations[slotId].length() < _MAX_RESERVATIONS) &&

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -11,11 +11,10 @@ contract SlotReservations {
 
   uint8 private constant _MAX_RESERVATIONS = 3;
 
-  function reserveSlot(SlotId slotId) public returns (bool) {
+  function reserveSlot(SlotId slotId) public {
     address host = msg.sender;
     require(canReserveSlot(slotId), "Reservation not allowed");
-    // returns false if set already contains address
-    return _reservations[slotId].add(host);
+    _reservations[slotId].add(host);
   }
 
   function canReserveSlot(SlotId slotId) public view returns (bool) {

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -3,13 +3,17 @@ pragma solidity 0.8.23;
 
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "./Requests.sol";
+import "./Configuration.sol";
 
 contract SlotReservations {
   using EnumerableSet for EnumerableSet.AddressSet;
 
   mapping(SlotId => EnumerableSet.AddressSet) internal _reservations;
+  SlotReservationsConfig private _config;
 
-  uint8 private constant _MAX_RESERVATIONS = 3;
+  constructor(SlotReservationsConfig memory config) {
+    _config = config;
+  }
 
   function reserveSlot(RequestId requestId, uint256 slotIndex) public {
     require(canReserveSlot(requestId, slotIndex), "Reservation not allowed");
@@ -18,12 +22,15 @@ contract SlotReservations {
     _reservations[slotId].add(msg.sender);
   }
 
-  function canReserveSlot(RequestId requestId, uint256 slotIndex) public view returns (bool) {
+  function canReserveSlot(
+    RequestId requestId,
+    uint256 slotIndex
+  ) public view returns (bool) {
     address host = msg.sender;
     SlotId slotId = Requests.slotId(requestId, slotIndex);
     return
       // TODO: add in check for address inside of expanding window
-      (_reservations[slotId].length() < _MAX_RESERVATIONS) &&
+      (_reservations[slotId].length() < _config.maxReservations) &&
       (!_reservations[slotId].contains(host));
   }
 }

--- a/contracts/TestSlotReservations.sol
+++ b/contracts/TestSlotReservations.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import "./SlotReservations.sol";
+
+contract TestSlotReservations is SlotReservations {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  function contains(SlotId slotId, address host) public view returns (bool) {
+    return _reservations[slotId].contains(host);
+  }
+
+  function length(SlotId slotId) public view returns (uint256) {
+    return _reservations[slotId].length();
+  }
+}

--- a/contracts/TestSlotReservations.sol
+++ b/contracts/TestSlotReservations.sol
@@ -6,6 +6,9 @@ import "./SlotReservations.sol";
 contract TestSlotReservations is SlotReservations {
   using EnumerableSet for EnumerableSet.AddressSet;
 
+  // solhint-disable-next-line no-empty-blocks
+  constructor(SlotReservationsConfig memory config) SlotReservations(config) {}
+
   function contains(SlotId slotId, address host) public view returns (bool) {
     return _reservations[slotId].contains(host);
   }

--- a/deploy/marketplace.js
+++ b/deploy/marketplace.js
@@ -16,6 +16,9 @@ const CONFIGURATION = {
     downtime: 64,
     downtimeProduct: 67
   },
+  reservations: {
+    maxReservations: 3
+  }
 }
 
 async function mine256blocks({ network, ethers }) {

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -1,6 +1,6 @@
 const { expect } = require("chai")
 const { ethers } = require("hardhat")
-const { exampleRequest } = require("./examples")
+const { exampleRequest, exampleConfiguration } = require("./examples")
 const { requestId, slotId } = require("./ids")
 
 describe("SlotReservations", function () {
@@ -11,12 +11,13 @@ describe("SlotReservations", function () {
   let slot
   let slotIndex
   let id // can't use slotId because it'll shadow the function slotId
+  const config = exampleConfiguration()
 
   beforeEach(async function () {
     let SlotReservations = await ethers.getContractFactory(
       "TestSlotReservations"
     )
-    reservations = await SlotReservations.deploy()
+    reservations = await SlotReservations.deploy(config.reservations)
     ;[provider, address1, address2, address3] = await ethers.getSigners()
 
     request = await exampleRequest()

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -1,0 +1,73 @@
+const { expect } = require("chai")
+const { ethers } = require("hardhat")
+const { exampleRequest, exampleAddress } = require("./examples")
+const { requestId, slotId } = require("./ids")
+
+describe("SlotReservations", function () {
+  let reservations
+  let provider, address1, address2, address3
+  let request
+  let slot
+
+  beforeEach(async function () {
+    let SlotReservations = await ethers.getContractFactory("SlotReservations")
+    reservations = await SlotReservations.deploy()
+
+    provider = exampleAddress()
+    address1 = exampleAddress()
+    address2 = exampleAddress()
+    address3 = exampleAddress()
+
+    request = await exampleRequest()
+    request.client = exampleAddress()
+
+    slot = {
+      request: requestId(request),
+      index: request.ask.slots / 2,
+    }
+  })
+
+  it("allows a slot to be reserved", async function () {
+    let reserved = await reservations.callStatic.reserveSlot(
+      slotId(slot),
+      provider
+    )
+    expect(reserved).to.be.true
+  })
+
+  it("reports a slot can be reserved", async function () {
+    expect(await reservations.canReserveSlot(slotId(slot), provider)).to.be.true
+  })
+
+  it("cannot reserve a slot more than once", async function () {
+    let id = slotId(slot)
+    await reservations.reserveSlot(id, provider)
+    await expect(reservations.reserveSlot(id, provider)).to.be.revertedWith(
+      "Reservation not allowed"
+    )
+  })
+
+  it("reports a slot cannot be reserved if already reserved", async function () {
+    let id = slotId(slot)
+    await reservations.reserveSlot(id, provider)
+    expect(await reservations.canReserveSlot(id, provider)).to.be.false
+  })
+
+  it("cannot reserve a slot if reservations are at capacity", async function () {
+    let id = slotId(slot)
+    await reservations.reserveSlot(id, address1)
+    await reservations.reserveSlot(id, address2)
+    await reservations.reserveSlot(id, address3)
+    await expect(reservations.reserveSlot(id, provider)).to.be.revertedWith(
+      "Reservation not allowed"
+    )
+  })
+
+  it("reports a slot cannot be reserved if reservations are at capacity", async function () {
+    let id = slotId(slot)
+    await reservations.reserveSlot(id, address1)
+    await reservations.reserveSlot(id, address2)
+    await reservations.reserveSlot(id, address3)
+    expect(await reservations.canReserveSlot(id, provider)).to.be.false
+  })
+})

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -8,6 +8,7 @@ describe("SlotReservations", function () {
   let provider, address1, address2, address3
   let request
   let slot
+  let id // can't use slotId because it'll shadow the function slotId
 
   beforeEach(async function () {
     let SlotReservations = await ethers.getContractFactory(
@@ -22,6 +23,8 @@ describe("SlotReservations", function () {
       request: requestId(request),
       index: request.ask.slots / 2,
     }
+
+    id = slotId(slot)
   })
 
   function switchAccount(account) {
@@ -29,13 +32,10 @@ describe("SlotReservations", function () {
   }
 
   it("allows a slot to be reserved", async function () {
-    let id = slotId(slot)
-    let reserved = await reservations.callStatic.reserveSlot(id)
-    expect(reserved).to.be.true
+    expect(reservations.reserveSlot(id)).to.not.be.reverted
   })
 
   it("contains the correct addresses after reservation", async function () {
-    let id = slotId(slot)
     await reservations.reserveSlot(id)
     expect(await reservations.contains(id, provider.address)).to.be.true
 
@@ -45,7 +45,6 @@ describe("SlotReservations", function () {
   })
 
   it("has the correct number of addresses after reservation", async function () {
-    let id = slotId(slot)
     await reservations.reserveSlot(id)
     expect(await reservations.length(id)).to.equal(1)
 
@@ -59,7 +58,6 @@ describe("SlotReservations", function () {
   })
 
   it("cannot reserve a slot more than once", async function () {
-    let id = slotId(slot)
     await reservations.reserveSlot(id)
     await expect(reservations.reserveSlot(id)).to.be.revertedWith(
       "Reservation not allowed"
@@ -68,13 +66,11 @@ describe("SlotReservations", function () {
   })
 
   it("reports a slot cannot be reserved if already reserved", async function () {
-    let id = slotId(slot)
     await reservations.reserveSlot(id)
     expect(await reservations.canReserveSlot(id)).to.be.false
   })
 
   it("cannot reserve a slot if reservations are at capacity", async function () {
-    let id = slotId(slot)
     switchAccount(address1)
     await reservations.reserveSlot(id)
     switchAccount(address2)
@@ -90,7 +86,6 @@ describe("SlotReservations", function () {
   })
 
   it("reports a slot cannot be reserved if reservations are at capacity", async function () {
-    let id = slotId(slot)
     switchAccount(address1)
     await reservations.reserveSlot(id)
     switchAccount(address2)

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -7,7 +7,9 @@ describe("SlotReservations", function () {
   let reservations
   let provider, address1, address2, address3
   let request
+  let reqId
   let slot
+  let slotIndex
   let id // can't use slotId because it'll shadow the function slotId
 
   beforeEach(async function () {
@@ -18,12 +20,12 @@ describe("SlotReservations", function () {
     ;[provider, address1, address2, address3] = await ethers.getSigners()
 
     request = await exampleRequest()
-
+    reqId = requestId(request)
+    slotIndex = request.ask.slots / 2
     slot = {
-      request: requestId(request),
-      index: request.ask.slots / 2,
+      request: reqId,
+      index: slotIndex,
     }
-
     id = slotId(slot)
   })
 
@@ -32,53 +34,53 @@ describe("SlotReservations", function () {
   }
 
   it("allows a slot to be reserved", async function () {
-    expect(reservations.reserveSlot(id)).to.not.be.reverted
+    expect(reservations.reserveSlot(reqId, slotIndex)).to.not.be.reverted
   })
 
   it("contains the correct addresses after reservation", async function () {
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     expect(await reservations.contains(id, provider.address)).to.be.true
 
     switchAccount(address1)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     expect(await reservations.contains(id, address1.address)).to.be.true
   })
 
   it("has the correct number of addresses after reservation", async function () {
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     expect(await reservations.length(id)).to.equal(1)
 
     switchAccount(address1)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     expect(await reservations.length(id)).to.equal(2)
   })
 
   it("reports a slot can be reserved", async function () {
-    expect(await reservations.canReserveSlot(slotId(slot))).to.be.true
+    expect(await reservations.canReserveSlot(reqId, slotIndex)).to.be.true
   })
 
   it("cannot reserve a slot more than once", async function () {
-    await reservations.reserveSlot(id)
-    await expect(reservations.reserveSlot(id)).to.be.revertedWith(
+    await reservations.reserveSlot(reqId, slotIndex)
+    await expect(reservations.reserveSlot(reqId, slotIndex)).to.be.revertedWith(
       "Reservation not allowed"
     )
     expect(await reservations.length(id)).to.equal(1)
   })
 
   it("reports a slot cannot be reserved if already reserved", async function () {
-    await reservations.reserveSlot(id)
-    expect(await reservations.canReserveSlot(id)).to.be.false
+    await reservations.reserveSlot(reqId, slotIndex)
+    expect(await reservations.canReserveSlot(reqId, slotIndex)).to.be.false
   })
 
   it("cannot reserve a slot if reservations are at capacity", async function () {
     switchAccount(address1)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     switchAccount(address2)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     switchAccount(address3)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     switchAccount(provider)
-    await expect(reservations.reserveSlot(id)).to.be.revertedWith(
+    await expect(reservations.reserveSlot(reqId, slotIndex)).to.be.revertedWith(
       "Reservation not allowed"
     )
     expect(await reservations.length(id)).to.equal(3)
@@ -87,12 +89,12 @@ describe("SlotReservations", function () {
 
   it("reports a slot cannot be reserved if reservations are at capacity", async function () {
     switchAccount(address1)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     switchAccount(address2)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     switchAccount(address3)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     switchAccount(provider)
-    expect(await reservations.canReserveSlot(id)).to.be.false
+    expect(await reservations.canReserveSlot(reqId, slotIndex)).to.be.false
   })
 })

--- a/test/examples.js
+++ b/test/examples.js
@@ -51,12 +51,9 @@ const invalidProof = () => ({
   c: { x: 0, y: 0 },
 })
 
-const exampleAddress = () => hexlify(randomBytes(20))
-
 module.exports = {
   exampleConfiguration,
   exampleRequest,
   exampleProof,
   invalidProof,
-  exampleAddress,
 }

--- a/test/examples.js
+++ b/test/examples.js
@@ -16,6 +16,9 @@ const exampleConfiguration = () => ({
     zkeyHash: "",
     downtimeProduct: 67,
   },
+  reservations: {
+    maxReservations: 3,
+  },
 })
 
 const exampleRequest = async () => {

--- a/test/examples.js
+++ b/test/examples.js
@@ -51,9 +51,12 @@ const invalidProof = () => ({
   c: { x: 0, y: 0 },
 })
 
+const exampleAddress = () => hexlify(randomBytes(20))
+
 module.exports = {
   exampleConfiguration,
   exampleRequest,
   exampleProof,
   invalidProof,
+  exampleAddress,
 }


### PR DESCRIPTION
Closes #175. 

These functions are not called yet. They are being implemented as part of a [longer list of tasks for slot reservations](https://github.com/codex-storage/codex-pm/issues/45) to prevent PRs from being too large.

Allows reservation of slots, without an implementation of the expanding window.

- Add a function called `reserveSlot(address, SlotId)`, that allows three unique addresses per slot to be reserved. 
  - Revert if reservations full or if provider address already reserved slot
  - Use `mapping(SlotId => EnumerableSet.AddressSet)`
- Add `canReserveSlot(address, SlotId)`
  - Return `true` if set of reservations is less than 3 and the set doesn't already contain the address
  - Return `true` otherwise (for now, later add in logic for checking the address is inside the expanding window)
  - Call `canReserveSlot` from `reserveSlot` as a `require` or invariant