### PR TITLE
feat(slot-reservations): Add `SlotReservationsFull` event

### DIFF
--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -22,7 +22,7 @@ contract SlotReservations {
     _reservations[slotId].add(msg.sender);
 
     if (_reservations[slotId].length() == _MAX_RESERVATIONS) {
-      emit SlotReservationsFull(slotId);
+      emit SlotReservationsFull(requestId, slotIndex);
     }
   }
 
@@ -38,5 +38,5 @@ contract SlotReservations {
       (!_reservations[slotId].contains(host));
   }
 
-  event SlotReservationsFull(SlotId indexed slotId);
+  event SlotReservationsFull(RequestId indexed requestId, uint256 slotIndex);
 }

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -21,7 +21,7 @@ contract SlotReservations {
     SlotId slotId = Requests.slotId(requestId, slotIndex);
     _reservations[slotId].add(msg.sender);
 
-    if (_reservations[slotId].length() == _MAX_RESERVATIONS) {
+    if (_reservations[slotId].length() == _config.maxReservations) {
       emit SlotReservationsFull(requestId, slotIndex);
     }
   }

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -20,6 +20,10 @@ contract SlotReservations {
 
     SlotId slotId = Requests.slotId(requestId, slotIndex);
     _reservations[slotId].add(msg.sender);
+
+    if (_reservations[slotId].length() == _MAX_RESERVATIONS) {
+      emit SlotReservationsFull(slotId);
+    }
   }
 
   function canReserveSlot(
@@ -33,4 +37,6 @@ contract SlotReservations {
       (_reservations[slotId].length() < _config.maxReservations) &&
       (!_reservations[slotId].contains(host));
   }
+
+  event SlotReservationsFull(SlotId indexed slotId);
 }

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -100,17 +100,19 @@ describe("SlotReservations", function () {
   })
 
   it("should emit an event when slot reservations are full", async function () {
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     switchAccount(address1)
-    await reservations.reserveSlot(id)
+    await reservations.reserveSlot(reqId, slotIndex)
     switchAccount(address2)
-    await expect(reservations.reserveSlot(id))
+    await expect(reservations.reserveSlot(reqId, slotIndex))
       .to.emit(reservations, "SlotReservationsFull")
-      .withArgs(id)
+      .withArgs(reqId, slotIndex)
   })
 
   it("should not emit an event when reservations are not full", async function () {
-    await expect(reservations.reserveSlot(id))
-      .to.not.emit(reservations, "SlotReservationsFull")
+    await expect(reservations.reserveSlot(reqId, slotIndex)).to.not.emit(
+      reservations,
+      "SlotReservationsFull"
+    )
   })
 })

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -98,4 +98,19 @@ describe("SlotReservations", function () {
     switchAccount(provider)
     expect(await reservations.canReserveSlot(reqId, slotIndex)).to.be.false
   })
+
+  it("should emit an event when slot reservations are full", async function () {
+    await reservations.reserveSlot(id)
+    switchAccount(address1)
+    await reservations.reserveSlot(id)
+    switchAccount(address2)
+    await expect(reservations.reserveSlot(id))
+      .to.emit(reservations, "SlotReservationsFull")
+      .withArgs(id)
+  })
+
+  it("should not emit an event when reservations are not full", async function () {
+    await expect(reservations.reserveSlot(id))
+      .to.not.emit(reservations, "SlotReservationsFull")
+  })
 })


### PR DESCRIPTION
Closes #182.

This is being implemented as part of a [longer list of tasks for slot reservations](https://github.com/codex-storage/codex-pm/issues/45) to prevent PRs from being too large.

When the number of reservations for a slot reaches `config._MAX_RESERVATIONS`, a `SlotReservationsFull` event is emitted with the `RequestId` and `slotIndex` of the slot.