### PR TITLE
feat(slot-reservations): require slots to be reserved before filling slot

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -14,6 +14,7 @@ import "./Groth16.sol";
 
 contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   using EnumerableSet for EnumerableSet.Bytes32Set;
+  using EnumerableSet for EnumerableSet.AddressSet;
   using Requests for Request;
 
   IERC20 private immutable _token;
@@ -136,6 +137,8 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     require(slotIndex < request.ask.slots, "Invalid slot");
 
     SlotId slotId = Requests.slotId(requestId, slotIndex);
+    require(_reservations[slotId].contains(msg.sender), "Reservation required");
+
     Slot storage slot = _slots[slotId];
     slot.requestId = requestId;
     slot.slotIndex = slotIndex;

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -344,6 +344,12 @@ describe("Marketplace", function () {
         marketplace.fillSlot(slot.request, lastSlot, proof)
       ).to.be.revertedWith("Slot is not free")
     })
+
+    it("fails if slot is not reserved first", async function () {
+      await expect(
+        marketplace.fillSlot(slot.request, slot.index, proof)
+      ).to.be.revertedWith("Reservation required")
+    })
   })
 
   describe("filling slot without collateral", function () {

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -18,6 +18,7 @@ async function waitUntilStarted(contract, request, proof, token) {
   await token.approve(contract.address, price(request) * request.ask.slots)
 
   for (let i = 0; i < request.ask.slots; i++) {
+    await contract.reserveSlot(requestId(request), i)
     await contract.fillSlot(requestId(request), i, proof)
   }
 }


### PR DESCRIPTION
Closes #184.

This is being implemented as part of a [longer list of tasks for slot reservations](https://github.com/codex-storage/codex-pm/issues/45) to prevent PRs from being too large.

Requires that a slot is reserved before slot is allowed to be filled.