### PR TITLE
feat: repair reward

### DIFF
--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -301,10 +301,7 @@ rule functionsCausingSlotStateChanges(env e, method f) {
     assert slotStateBefore == Marketplace.SlotState.Finished && slotStateAfter == Marketplace.SlotState.Paid => canMakeSlotPaid(f);
 
     // SlotState.Free -> SlotState.Filled
-    assert slotStateBefore != Marketplace.SlotState.Free && slotStateAfter == Marketplace.SlotState.Filled => canFillSlot(f);
-
-    // SlotState.Repair -> SlotState.Filled
-    assert slotStateBefore != Marketplace.SlotState.Repair && slotStateAfter == Marketplace.SlotState.Filled => canFillSlot(f);
+    assert (slotStateBefore != Marketplace.SlotState.Free || slotStateBefore != Marketplace.SlotState.Repair) && slotStateAfter == Marketplace.SlotState.Filled => canFillSlot(f);
 }
 
 rule allowedSlotStateChanges(env e, method f) {
@@ -329,7 +326,7 @@ rule allowedSlotStateChanges(env e, method f) {
             slotStateAfter == Marketplace.SlotState.Paid
             );
 
-    // SlotState.Filled only from Free
+    // SlotState.Filled only from Free or Repair
     assert slotStateBefore != Marketplace.SlotState.Filled && slotStateAfter == Marketplace.SlotState.Filled => (slotStateBefore == Marketplace.SlotState.Free || slotStateBefore == Marketplace.SlotState.Repair);
 }
 

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -330,7 +330,7 @@ rule allowedSlotStateChanges(env e, method f) {
             );
 
     // SlotState.Filled only from Free
-    assert slotStateBefore != Marketplace.SlotState.Filled && slotStateAfter == Marketplace.SlotState.Filled => slotStateBefore == Marketplace.SlotState.Free;
+    assert slotStateBefore != Marketplace.SlotState.Filled && slotStateAfter == Marketplace.SlotState.Filled => (slotStateBefore == Marketplace.SlotState.Free || slotStateBefore == Marketplace.SlotState.Repair);
 }
 
 rule cancelledRequestsStayCancelled(env e, method f) {

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -301,7 +301,10 @@ rule functionsCausingSlotStateChanges(env e, method f) {
     assert slotStateBefore == Marketplace.SlotState.Finished && slotStateAfter == Marketplace.SlotState.Paid => canMakeSlotPaid(f);
 
     // SlotState.Free -> SlotState.Filled
-    assert slotStateBefore != Marketplace.SlotState.Filled && slotStateAfter == Marketplace.SlotState.Filled => canFillSlot(f);
+    assert slotStateBefore != Marketplace.SlotState.Free && slotStateAfter == Marketplace.SlotState.Filled => canFillSlot(f);
+
+    // SlotState.Repair -> SlotState.Filled
+    assert slotStateBefore != Marketplace.SlotState.Repair && slotStateAfter == Marketplace.SlotState.Filled => canFillSlot(f);
 }
 
 rule allowedSlotStateChanges(env e, method f) {

--- a/certora/specs/Marketplace.spec
+++ b/certora/specs/Marketplace.spec
@@ -301,7 +301,7 @@ rule functionsCausingSlotStateChanges(env e, method f) {
     assert slotStateBefore == Marketplace.SlotState.Finished && slotStateAfter == Marketplace.SlotState.Paid => canMakeSlotPaid(f);
 
     // SlotState.Free -> SlotState.Filled
-    assert (slotStateBefore != Marketplace.SlotState.Free || slotStateBefore != Marketplace.SlotState.Repair) && slotStateAfter == Marketplace.SlotState.Filled => canFillSlot(f);
+    assert (slotStateBefore == Marketplace.SlotState.Free || slotStateBefore == Marketplace.SlotState.Repair) && slotStateAfter == Marketplace.SlotState.Filled => canFillSlot(f);
 }
 
 rule allowedSlotStateChanges(env e, method f) {

--- a/contracts/Configuration.sol
+++ b/contracts/Configuration.sol
@@ -10,10 +10,7 @@ struct MarketplaceConfig {
 }
 
 struct CollateralConfig {
-  /// @dev percentage of remaining collateral slot after it has been freed
-  /// (equivalent to `collateral - (collateral*maxNumberOfSlashes*slashPercentage)/100`)
-  /// TODO: to be aligned more closely with actual cost of repair once bandwidth incentives are known,
-  /// see https://github.com/codex-storage/codex-contracts-eth/pull/47#issuecomment-1465511949.
+  /// @dev percentage of collateral that is used as repair reward
   uint8 repairRewardPercentage;
   uint8 maxNumberOfSlashes; // frees slot when the number of slashing reaches this value
   uint16 slashCriterion; // amount of proofs missed that lead to slashing

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -188,7 +188,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
 
     if (
       context.slotsFilled == request.ask.slots &&
-      context.state != RequestState.Started // In case of repair, we already have the request started, so we prevent from "restarting it"
+      context.state == RequestState.New // Only New requests can "start" the requests
     ) {
       context.state = RequestState.Started;
       context.startedAt = block.timestamp;

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -126,7 +126,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   }
 
   /**
-   * @notice Fills a slot. Reverts if an invalid proof of the slot data is
+     * @notice Fills a slot. Reverts if an invalid proof of the slot data is
      provided.
    * @param requestId RequestId identifying the request containing the slot to
      fill.
@@ -197,7 +197,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   }
 
   /**
-   * @notice Frees a slot, paying out rewards and returning collateral for
+     * @notice Frees a slot, paying out rewards and returning collateral for
      finished or cancelled requests to the host that has filled the slot.
    * @param slotId id of the slot to free
    * @dev The host that filled the slot must have initiated the transaction
@@ -209,7 +209,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   }
 
   /**
-   * @notice Frees a slot, paying out rewards and returning collateral for
+     * @notice Frees a slot, paying out rewards and returning collateral for
      finished or cancelled requests.
    * @param slotId id of the slot to free
    * @param rewardRecipient address to send rewards to
@@ -299,7 +299,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   }
 
   /**
-   * @notice Abandons the slot without returning collateral, effectively slashing the
+     * @notice Abandons the slot without returning collateral, effectively slashing the
      entire collateral.
    * @param slotId SlotId of the slot to free.
    * @dev _slots[slotId] is deleted, resetting _slots[slotId].currentCollateral
@@ -315,13 +315,13 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     context.fundsToReturnToClient += _slotPayout(requestId, slot.filledAt);
 
     _removeFromMySlots(slot.host, slotId);
-    uint256 slotIndex = slot.slotIndex;
-    delete _slots[slotId];
     delete _reservations[slotId]; // We purge all the reservations for the slot
     slot.state = SlotState.Repair;
-    slot.requestId = requestId;
+    slot.filledAt = 0;
+    slot.currentCollateral = 0;
+    slot.host = address(0);
     context.slotsFilled -= 1;
-    emit SlotFreed(requestId, slotIndex);
+    emit SlotFreed(requestId, slot.slotIndex);
     _resetMissingProofs(slotId);
 
     Request storage request = _requests[requestId];
@@ -359,7 +359,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   }
 
   /**
-   * @notice Pays out a host for duration of time that the slot was filled, and
+     * @notice Pays out a host for duration of time that the slot was filled, and
      returns the collateral.
    * @dev The payouts are sent to the rewardRecipient, and collateral is returned
      to the host address.
@@ -389,7 +389,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   }
 
   /**
-   * @notice Withdraws remaining storage request funds back to the client that
+     * @notice Withdraws remaining storage request funds back to the client that
      deposited them.
    * @dev Request must be cancelled, failed or finished, and the
      transaction must originate from the depositor address.
@@ -400,7 +400,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   }
 
   /**
-   * @notice Withdraws storage request funds to the provided address.
+     * @notice Withdraws storage request funds to the provided address.
    * @dev Request must be expired, must be in RequestState.New, and the
      transaction must originate from the depositer address.
    * @param requestId the id of the request

--- a/contracts/Requests.sol
+++ b/contracts/Requests.sol
@@ -36,12 +36,13 @@ enum RequestState {
 }
 
 enum SlotState {
-  Free, // [default] not filled yet, or host has vacated the slot
+  Free, // [default] not filled yet
   Filled, // host has filled slot
   Finished, // successfully completed
   Failed, // the request has failed
   Paid, // host has been paid
-  Cancelled // when request was cancelled then slot is cancelled as well
+  Cancelled, // when request was cancelled then slot is cancelled as well
+  Repair // when slot slot was forcible freed (host was kicked out from hosting the slot because of too many missed proofs) and needs to be repaired
 }
 
 library Requests {

--- a/test/requests.js
+++ b/test/requests.js
@@ -16,6 +16,7 @@ const SlotState = {
   Failed: 3,
   Paid: 4,
   Cancelled: 5,
+  Repair: 6,
 }
 
 function enableRequestAssertions() {


### PR DESCRIPTION
Closes #154 

The reward is attributed using a discount provided for the collateral required to be deposited. In this way, the reward is actually paid out at the end of Storage Request where the full amount of collateral is returned (provided no slashing occurred).