### PR TITLE
renames config to configuration

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -88,7 +88,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     _config = configuration;
   }
 
-  function config() public view returns (MarketplaceConfig memory) {
+  function configuration() public view returns (MarketplaceConfig memory) {
     return _config;
   }
 


### PR DESCRIPTION
This is not the right reason to be making this kind of change, but a very hard to debug symbol clash in codex for `config`. Changing this to `configuration` is the easiest way to fix the issue.

I spent nearly an entire day unsuccessfully trying to solve a strange symbol clash with `config` inside the integration tests. This was a last resort, and it works. Alternative attempts to solve the clash are welcome.

This is part of the getting the latest ethers merged into codex (to fix the nonce issue plaguing the testnet).