### PR TITLE
Add workaround for websocket subscription issues

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -24,6 +24,11 @@ module.exports = {
   networks: {
     hardhat: {
       tags: ["local"],
+      mining: {
+        auto: true,
+        // Workaround for https://github.com/NomicFoundation/hardhat/issues/2053
+        interval: 4 * 60 * 1000
+      }
     },
     codexdisttestnetwork: {
       url: `${process.env.DISTTEST_NETWORK_URL}`,


### PR DESCRIPTION
Mine a block every 4 minutes, to keep hardhat from forgetting about websocket subscriptions after 5
minutes.