### PR TITLE
Increase proof period to 90 seconds on hardhat network

### DIFF
--- a/configuration/networks/hardhat/configuration.js
+++ b/configuration/networks/hardhat/configuration.js
@@ -8,10 +8,10 @@ module.exports = {
   proofs: {
     // period has to be less than downtime * blocktime
     // blocktime can be 1 second with hardhat in automine mode
-    period: 60, // seconds
+    period: 90, // seconds
     timeout: 30, // seconds
-    downtime: 64, // number of blocks
-    downtimeProduct: 67 // number of blocks
+    downtime: 96, // number of blocks
+    downtimeProduct: 97 // number of blocks
   },
   reservations: {
     maxReservations: 3


### PR DESCRIPTION
Reason: on windows, the nim-codex integration tests run so slow that they cannot fill a slot within 60 seconds.
Slowness is most likely caused by https://github.com/codex-storage/nim-ethers/issues/95.