### PR TITLE
ci: tweaks run triggers and checkout hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -20,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       # workaround for https://github.com/NomicFoundation/hardhat/issues/3877
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Tweaks the CI trigger limiting "push" trigger only to `master` and also configures to checkout the true PR branch.