### PR TITLE
Replace assert with revert

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -376,8 +376,13 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     uint256 collateralAmount = slot.currentCollateral;
     _marketplaceTotals.sent += (payoutAmount + collateralAmount);
     slot.state = SlotState.Paid;
-    assert(_token.transfer(rewardRecipient, payoutAmount));
-    assert(_token.transfer(collateralRecipient, collateralAmount));
+    if (!_token.transfer(rewardRecipient, payoutAmount)) {
+      revert Marketplace_TransferFailed();
+    }
+
+    if (!_token.transfer(collateralRecipient, collateralAmount)) {
+      revert Marketplace_TransferFailed();
+    }
   }
 
   /**
@@ -406,8 +411,12 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     uint256 collateralAmount = slot.currentCollateral;
     _marketplaceTotals.sent += (payoutAmount + collateralAmount);
     slot.state = SlotState.Paid;
-    assert(_token.transfer(rewardRecipient, payoutAmount));
-    assert(_token.transfer(collateralRecipient, collateralAmount));
+    if (!_token.transfer(rewardRecipient, payoutAmount)) {
+      revert Marketplace_TransferFailed();
+    }
+    if (!_token.transfer(collateralRecipient, collateralAmount)) {
+      revert Marketplace_TransferFailed();
+    }
   }
 
   /**
@@ -473,7 +482,10 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
 
     uint256 amount = context.fundsToReturnToClient;
     _marketplaceTotals.sent += amount;
-    assert(_token.transfer(withdrawRecipient, amount));
+
+    if (!_token.transfer(withdrawRecipient, amount)) {
+      revert Marketplace_TransferFailed();
+    }
 
     // We zero out the funds tracking in order to prevent double-spends
     context.fundsToReturnToClient = 0;


### PR DESCRIPTION
Fix #149. 

Since we switched to custom errors, I used `revert` instead of `required`.