### PR TITLE
simplify time-based logic in tests, and fix requestEnd()

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -558,13 +558,15 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   }
 
   function requestEnd(RequestId requestId) public view returns (uint64) {
-    uint64 end = _requestContexts[requestId].endsAt;
     RequestState state = requestState(requestId);
     if (state == RequestState.New || state == RequestState.Started) {
-      return end;
-    } else {
-      return uint64(Math.min(end, block.timestamp - 1));
+      return _requestContexts[requestId].endsAt;
     }
+    if (state == RequestState.Cancelled) {
+      return _requestContexts[requestId].expiresAt;
+    }
+    return
+      uint64(Math.min(_requestContexts[requestId].endsAt, block.timestamp));
   }
 
   function requestExpiry(RequestId requestId) public view returns (uint64) {

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -24,6 +24,7 @@ module.exports = {
   networks: {
     hardhat: {
       tags: ["local"],
+      allowBlocksWithSameTimestamp: true
     },
     codexdisttestnetwork: {
       url: `${process.env.DISTTEST_NETWORK_URL}`,

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -696,7 +696,7 @@ describe("Marketplace", function () {
       ).toNumber()
 
       await marketplace.reserveSlot(slot.request, slot.index)
-      await advanceTimeTo(filledAt)
+      await setNextBlockTimestamp(filledAt)
       await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(marketplace, request)
       await marketplace.freeSlot(slotId(slot))
@@ -717,7 +717,7 @@ describe("Marketplace", function () {
       ).toNumber()
 
       await marketplace.reserveSlot(slot.request, slot.index)
-      await advanceTimeTo(filledAt)
+      await setNextBlockTimestamp(filledAt)
       await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(marketplace, request)
       const startBalanceHost = await token.balanceOf(host.address)
@@ -1009,7 +1009,7 @@ describe("Marketplace", function () {
       ).toNumber()
 
       await marketplace.reserveSlot(slot.request, slot.index)
-      await advanceTimeTo(filledAt)
+      await setNextBlockTimestamp(filledAt)
       await marketplace.fillSlot(slot.request, slot.index, proof)
       await waitUntilCancelled(marketplace, request)
       const expectedPartialhostRewardRecipient =

--- a/test/evm.js
+++ b/test/evm.js
@@ -35,8 +35,12 @@ async function advanceTime(seconds) {
 }
 
 async function advanceTimeTo(timestamp) {
-  await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp])
+  await setNextBlockTimestamp(timestamp)
   await mine()
+}
+
+async function setNextBlockTimestamp(timestamp) {
+  await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp])
 }
 
 module.exports = {
@@ -47,4 +51,5 @@ module.exports = {
   currentTime,
   advanceTime,
   advanceTimeTo,
+  setNextBlockTimestamp,
 }

--- a/test/evm.js
+++ b/test/evm.js
@@ -11,16 +11,9 @@ async function snapshot() {
 async function revert() {
   const { id, time } = snapshots.pop()
   await ethers.provider.send("evm_revert", [id])
-  await ethers.provider.send("evm_setNextBlockTimestamp", [time + 1])
+  await ethers.provider.send("evm_setNextBlockTimestamp", [time])
 }
 
-/**
- * Mines new block.
- *
- * This call increases the block's timestamp by 1!
- *
- * @returns {Promise<void>}
- */
 async function mine() {
   await ethers.provider.send("evm_mine")
 }
@@ -36,30 +29,14 @@ async function currentTime() {
   return block.timestamp
 }
 
-/**
- * Function that advances time by adding seconds to current timestamp for **next block**.
- *
- * If you need the timestamp to be already applied for current block then mine a new block with `mine()` after this call.
- * This is mainly needed when doing assertions on top of view calls that does not create transactions and mine new block.
- *
- * @param timestamp
- * @returns {Promise<void>}
- */
-async function advanceTimeForNextBlock(seconds) {
+async function advanceTime(seconds) {
   await ethers.provider.send("evm_increaseTime", [seconds])
+  await mine()
 }
 
-/**
- * Function that sets specific timestamp for **next block**.
- *
- * If you need the timestamp to be already applied for current block then mine a new block with `mine()` after this call.
- * This is mainly needed when doing assertions on top of view calls that does not create transactions and mine new block.
- *
- * @param timestamp
- * @returns {Promise<void>}
- */
-async function advanceTimeToForNextBlock(timestamp) {
+async function advanceTimeTo(timestamp) {
   await ethers.provider.send("evm_setNextBlockTimestamp", [timestamp])
+  await mine()
 }
 
 module.exports = {
@@ -68,6 +45,6 @@ module.exports = {
   mine,
   ensureMinimumBlockHeight,
   currentTime,
-  advanceTimeForNextBlock,
-  advanceTimeToForNextBlock,
+  advanceTime,
+  advanceTimeTo,
 }

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -1,6 +1,6 @@
-const { advanceTimeToForNextBlock, currentTime } = require("./evm")
+const { advanceTimeTo, currentTime, mine } = require("./evm")
 const { slotId, requestId } = require("./ids")
-const { maxPrice, payoutForDuration } = require("./price")
+const { payoutForDuration } = require("./price")
 const { collateralPerSlot } = require("./collateral")
 
 /**
@@ -12,7 +12,7 @@ const { collateralPerSlot } = require("./collateral")
  */
 async function waitUntilCancelled(request) {
   // We do +1, because the expiry check in contract is done as `>` and not `>=`.
-  await advanceTimeToForNextBlock((await currentTime()) + request.expiry + 1)
+  await advanceTimeTo((await currentTime()) + request.expiry + 1)
 }
 
 async function waitUntilSlotsFilled(contract, request, proof, token, slots) {
@@ -48,7 +48,7 @@ async function waitUntilStarted(contract, request, proof, token) {
 async function waitUntilFinished(contract, requestId) {
   const end = (await contract.requestEnd(requestId)).toNumber()
   // We do +1, because the end check in contract is done as `>` and not `>=`.
-  await advanceTimeToForNextBlock(end + 1)
+  await advanceTimeTo(end + 1)
 }
 
 async function waitUntilFailed(contract, request) {

--- a/test/marketplace.js
+++ b/test/marketplace.js
@@ -1,18 +1,12 @@
-const { advanceTimeTo, currentTime, mine } = require("./evm")
+const { advanceTimeTo, currentTime } = require("./evm")
 const { slotId, requestId } = require("./ids")
 const { payoutForDuration } = require("./price")
 const { collateralPerSlot } = require("./collateral")
 
-/**
- * @dev This will not advance the time right on the "expiry threshold" but will most probably "overshoot it"
- *      because "currentTime" most probably is not the time at which the request is created, but it is used
- *      in the next timestamp calculation with `now + expiry`.
- * @param request
- * @returns {Promise<void>}
- */
-async function waitUntilCancelled(request) {
+async function waitUntilCancelled(contract, request) {
+  const expiry = (await contract.requestExpiry(requestId(request))).toNumber()
   // We do +1, because the expiry check in contract is done as `>` and not `>=`.
-  await advanceTimeTo((await currentTime()) + request.expiry + 1)
+  await advanceTimeTo(expiry + 1)
 }
 
 async function waitUntilSlotsFilled(contract, request, proof, token, slots) {


### PR DESCRIPTION
- use the `allowBlocksWithSameTimestamp` hardhat option
- remove block time gymnastics from marketplace tests
- fix erroneous implementation of requestEnd() which surfaced because of the the improved tests