### PR TITLE
chore: add a new canMarkProofAsMissing function

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -335,7 +335,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     _proofReceived(id, proof, pubSignals);
   }
 
-  function canProofBeMarkedAsMissing(
+  function canMarkProofAsMissing(
     SlotId slotId,
     Period period
   ) public view slotAcceptsProofs(slotId) {

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -335,11 +335,19 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     _proofReceived(id, proof, pubSignals);
   }
 
-  function markProofAsMissing(SlotId slotId, Period period) public {
-    if (slotState(slotId) != SlotState.Filled)
-      revert Marketplace_SlotNotAcceptingProofs();
+  function canProofBeMarkedAsMissing(
+    SlotId slotId,
+    Period period
+  ) public view slotIsFilled(slotId) {
+    _canMarkProofAsMissing(slotId, period);
+  }
 
+  function markProofAsMissing(
+    SlotId slotId,
+    Period period
+  ) public slotIsFilled(slotId) {
     _markProofAsMissing(slotId, period);
+
     Slot storage slot = _slots[slotId];
     Request storage request = _requests[slot.requestId];
 
@@ -349,7 +357,10 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     uint256 validatorRewardAmount = (slashedAmount *
       _config.collateral.validatorRewardPercentage) / 100;
     _marketplaceTotals.sent += validatorRewardAmount;
-    assert(_token.transfer(msg.sender, validatorRewardAmount));
+
+    if (!_token.transfer(msg.sender, validatorRewardAmount)) {
+      revert Marketplace_TransferFailed();
+    }
 
     slot.currentCollateral -= slashedAmount;
     if (missingProofs(slotId) >= _config.collateral.maxNumberOfSlashes) {
@@ -556,6 +567,12 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
 
   modifier slotIsNotFree(SlotId slotId) {
     if (_slots[slotId].state == SlotState.Free) revert Marketplace_SlotIsFree();
+    _;
+  }
+
+  modifier slotIsFilled(SlotId slotId) {
+    if (slotState(slotId) != SlotState.Filled)
+      revert Marketplace_SlotNotAcceptingProofs();
     _;
   }
 

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -338,14 +338,14 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   function canProofBeMarkedAsMissing(
     SlotId slotId,
     Period period
-  ) public view slotIsFilled(slotId) {
+  ) public view slotAcceptsProofs(slotId) {
     _canMarkProofAsMissing(slotId, period);
   }
 
   function markProofAsMissing(
     SlotId slotId,
     Period period
-  ) public slotIsFilled(slotId) {
+  ) public slotAcceptsProofs(slotId) {
     _markProofAsMissing(slotId, period);
 
     Slot storage slot = _slots[slotId];
@@ -570,7 +570,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     _;
   }
 
-  modifier slotIsFilled(SlotId slotId) {
+  modifier slotAcceptsProofs(SlotId slotId) {
     if (slotState(slotId) != SlotState.Filled)
       revert Marketplace_SlotNotAcceptingProofs();
     _;

--- a/contracts/Proofs.sol
+++ b/contracts/Proofs.sol
@@ -224,6 +224,16 @@ abstract contract Proofs is Periods {
    *    - proof was already marked as missing
    */
   function _markProofAsMissing(SlotId id, Period missedPeriod) internal {
+    _canMarkProofAsMissing(id, missedPeriod);
+
+    _missing[id][missedPeriod] = true;
+    _missed[id] += 1;
+  }
+
+  function _canMarkProofAsMissing(
+    SlotId id,
+    Period missedPeriod
+  ) internal view {
     uint256 end = _periodEnd(missedPeriod);
     if (end >= block.timestamp) revert Proofs_PeriodNotEnded();
     if (block.timestamp >= end + _config.timeout)
@@ -231,9 +241,6 @@ abstract contract Proofs is Periods {
     if (_received[id][missedPeriod]) revert Proofs_ProofNotMissing();
     if (!_isProofRequired(id, missedPeriod)) revert Proofs_ProofNotRequired();
     if (_missing[id][missedPeriod]) revert Proofs_ProofAlreadyMarkedMissing();
-
-    _missing[id][missedPeriod] = true;
-    _missed[id] += 1;
   }
 
   event ProofSubmitted(SlotId id);


### PR DESCRIPTION
This PR fixes https://github.com/codex-storage/nim-codex/issues/1153 by adding a new function in the contract, `canProofBeMarkedAsMissing`.

Since this function is a view and does not transfer reward funds to the validator, we should no longer encounter the `ERC20: transfer to the zero address` error.

Moreover, it updates the contracts since the `requestEnd` has been fixed in the contracts. 