### PR TITLE
fix(slot reservations): clear AddressSet instead of delete

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -376,7 +376,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     context.fundsToReturnToClient += _slotPayout(requestId, slot.filledAt);
 
     _removeFromMySlots(slot.host, slotId);
-    _clear(_reservations[slotId]); // We purge all the reservations for the slot
+    _reservations[slotId].clear(); // We purge all the reservations for the slot
     slot.state = SlotState.Repair;
     slot.filledAt = 0;
     slot.currentCollateral = 0;

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -376,7 +376,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     context.fundsToReturnToClient += _slotPayout(requestId, slot.filledAt);
 
     _removeFromMySlots(slot.host, slotId);
-    delete _reservations[slotId]; // We purge all the reservations for the slot
+    _clear(_reservations[slotId]); // We purge all the reservations for the slot
     slot.state = SlotState.Repair;
     slot.filledAt = 0;
     slot.currentCollateral = 0;

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -559,10 +559,6 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     _;
   }
 
-  function _slotIsFree(SlotId slotId) internal view override returns (bool) {
-    return _slots[slotId].state == SlotState.Free;
-  }
-
   function requestEnd(RequestId requestId) public view returns (uint64) {
     RequestState state = requestState(requestId);
     if (state == RequestState.New || state == RequestState.Started) {
@@ -636,7 +632,9 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     }
   }
 
-  function slotState(SlotId slotId) public view override returns (SlotState) {
+  function slotState(
+    SlotId slotId
+  ) public view override(Proofs, SlotReservations) returns (SlotState) {
     Slot storage slot = _slots[slotId];
     if (RequestId.unwrap(slot.requestId) == 0) {
       return SlotState.Free;

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -18,16 +18,6 @@ abstract contract SlotReservations {
 
   function slotState(SlotId id) public view virtual returns (SlotState);
 
-  /**
-   * Removes all addresses from the set
-   * @param set EnumerableSet.AddressSet to remove addresses from
-   */
-  function _clear(EnumerableSet.AddressSet storage set) internal {
-    for(uint8 i = 0; i < set.length(); i++) {
-        set.remove(set.at(i));
-    }
-  }
-
   function reserveSlot(RequestId requestId, uint64 slotIndex) public {
     if (!canReserveSlot(requestId, slotIndex))
       revert SlotReservations_ReservationNotAllowed();

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -18,6 +18,16 @@ abstract contract SlotReservations {
 
   function slotState(SlotId id) public view virtual returns (SlotState);
 
+  /**
+   * Removes all addresses from the set
+   * @param set EnumerableSet.AddressSet to remove addresses from
+   */
+  function _clear(EnumerableSet.AddressSet storage set) internal {
+    for(uint8 i = 0; i < set.length(); i++) {
+        set.remove(set.at(i));
+    }
+  }
+
   function reserveSlot(RequestId requestId, uint64 slotIndex) public {
     if (!canReserveSlot(requestId, slotIndex))
       revert SlotReservations_ReservationNotAllowed();

--- a/contracts/SlotReservations.sol
+++ b/contracts/SlotReservations.sol
@@ -16,7 +16,7 @@ abstract contract SlotReservations {
     _config = config;
   }
 
-  function _slotIsFree(SlotId slotId) internal view virtual returns (bool);
+  function slotState(SlotId id) public view virtual returns (SlotState);
 
   function reserveSlot(RequestId requestId, uint64 slotIndex) public {
     if (!canReserveSlot(requestId, slotIndex))
@@ -36,9 +36,10 @@ abstract contract SlotReservations {
   ) public view returns (bool) {
     address host = msg.sender;
     SlotId slotId = Requests.slotId(requestId, slotIndex);
+    SlotState state = slotState(slotId);
     return
       // TODO: add in check for address inside of expanding window
-      _slotIsFree(slotId) &&
+      (state == SlotState.Free || state == SlotState.Repair) &&
       (_reservations[slotId].length() < _config.maxReservations) &&
       (!_reservations[slotId].contains(host));
   }

--- a/contracts/TestSlotReservations.sol
+++ b/contracts/TestSlotReservations.sol
@@ -19,8 +19,8 @@ contract TestSlotReservations is SlotReservations {
     return _reservations[slotId].length();
   }
 
-  function _slotIsFree(SlotId slotId) internal view override returns (bool) {
-    return _states[slotId] == SlotState.Free;
+  function slotState(SlotId slotId) public view override returns (SlotState) {
+    return _states[slotId];
   }
 
   function setSlotState(SlotId id, SlotState state) public {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.2.1",
         "@nomiclabs/hardhat-waffle": "^2.0.3",
-        "@openzeppelin/contracts": "^5.2.0",
+        "@openzeppelin/contracts": "^5.3.0",
         "@stdlib/stats-binomial-test": "^0.0.7",
         "chai": "^4.3.7",
         "ethereum-waffle": "^3.4.4",
@@ -1764,10 +1764,11 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.2.0.tgz",
-      "integrity": "sha512-bxjNie5z89W1Ea0NZLZluFh8PrFNn9DH8DQlujEok2yjsOlraUPKID5p1Wk3qdNbf6XkQ1Os2RvfiHrrXLHWKA==",
-      "dev": true
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.3.0.tgz",
+      "integrity": "sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -24578,9 +24579,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.2.0.tgz",
-      "integrity": "sha512-bxjNie5z89W1Ea0NZLZluFh8PrFNn9DH8DQlujEok2yjsOlraUPKID5p1Wk3qdNbf6XkQ1Os2RvfiHrrXLHWKA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.3.0.tgz",
+      "integrity": "sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==",
       "dev": true
     },
     "@pnpm/config.env-replace": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.1",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
-    "@openzeppelin/contracts": "^5.2.0",
+    "@openzeppelin/contracts": "^5.3.0",
     "@stdlib/stats-binomial-test": "^0.0.7",
     "chai": "^4.3.7",
     "ethereum-waffle": "^3.4.4",

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -36,7 +36,7 @@ const {
   advanceTime,
   advanceTimeTo,
   currentTime,
-  setNextBlockTimestamp,
+  setNextBlockTimestamp
 } = require("./evm")
 const { arrayify } = require("ethers/lib/utils")
 
@@ -338,6 +338,7 @@ describe("Marketplace", function () {
           (collateral * config.collateral.repairRewardPercentage) / 100
         )
       await token.approve(marketplace.address, discountedCollateral)
+      await marketplace.reserveSlot(slot.request, slot.index)
       await marketplace.fillSlot(slot.request, slot.index, proof)
       const endBalance = await token.balanceOf(host.address)
       expect(startBalance - endBalance).to.equal(discountedCollateral)
@@ -408,7 +409,7 @@ describe("Marketplace", function () {
       await waitUntilFailed(marketplace, request)
       await expect(
         marketplace.fillSlot(slot.request, slot.index, proof)
-      ).to.be.revertedWith("Marketplace_SlotNotFree")
+      ).to.be.revertedWith("Marketplace_ReservationRequired")
     })
 
     it("is rejected when slot index not in range", async function () {
@@ -563,16 +564,19 @@ describe("Marketplace", function () {
 
   describe("freeing a slot", function () {
     let id
+    let collateral
 
     beforeEach(async function () {
       slot.index = 0
       id = slotId(slot)
+      period = config.proofs.period
+      ;({ periodOf, periodEnd } = periodic(period))
 
       switchAccount(client)
       await token.approve(marketplace.address, maxPrice(request))
       await marketplace.requestStorage(request)
       switchAccount(host)
-      const collateral = collateralPerSlot(request)
+      collateral = collateralPerSlot(request)
       await token.approve(marketplace.address, collateral)
     })
 
@@ -602,6 +606,16 @@ describe("Marketplace", function () {
       await expect(await marketplace.freeSlot(id))
         .to.emit(marketplace, "SlotFreed")
         .withArgs(slot.request, slot.index)
+    })
+
+    it("can reserve and fill a freed slot", async function () {
+      await waitUntilStarted(marketplace, request, proof, token)
+      await marketplace.freeSlot(id)
+      await marketplace.reserveSlot(slot.request, slot.index)
+      let currPeriod = periodOf(await currentTime())
+      await advanceTimeTo(periodEnd(currPeriod) + 1)
+      await token.approve(marketplace.address, collateral)
+      await marketplace.fillSlot(slot.request, slot.index, proof)
     })
   })
 

--- a/test/SlotReservations.test.js
+++ b/test/SlotReservations.test.js
@@ -37,7 +37,12 @@ describe("SlotReservations", function () {
     reservations = reservations.connect(account)
   }
 
-  it("allows a slot to be reserved", async function () {
+  it("allows a slot to be reserved if free", async function () {
+    expect(reservations.reserveSlot(reqId, slotIndex)).to.not.be.reverted
+  })
+
+  it("allows a slot to be reserved if in repair", async function () {
+    await reservations.setSlotState(id, SlotState.Repair)
     expect(reservations.reserveSlot(reqId, slotIndex)).to.not.be.reverted
   })
 
@@ -59,7 +64,13 @@ describe("SlotReservations", function () {
     expect(await reservations.length(id)).to.equal(2)
   })
 
-  it("reports a slot can be reserved", async function () {
+  it("reports a slot can be reserved if free", async function () {
+    await reservations.setSlotState(id, SlotState.Free)
+    expect(await reservations.canReserveSlot(reqId, slotIndex)).to.be.true
+  })
+
+  it("reports a slot can be reserved if in repair", async function () {
+    await reservations.setSlotState(id, SlotState.Repair)
     expect(await reservations.canReserveSlot(reqId, slotIndex)).to.be.true
   })
 
@@ -102,7 +113,7 @@ describe("SlotReservations", function () {
     expect(await reservations.canReserveSlot(reqId, slotIndex)).to.be.false
   })
 
-  it("cannot reserve a slot if not free", async function () {
+  it("cannot reserve a slot if not free or not in repair", async function () {
     await reservations.setSlotState(id, SlotState.Filled)
     await expect(reservations.reserveSlot(reqId, slotIndex)).to.be.revertedWith(
       "SlotReservations_ReservationNotAllowed"
@@ -110,7 +121,7 @@ describe("SlotReservations", function () {
     expect(await reservations.length(id)).to.equal(0)
   })
 
-  it("reports a slot cannot be reserved if not free", async function () {
+  it("reports a slot cannot be reserved if not free or not in repair", async function () {
     await reservations.setSlotState(id, SlotState.Filled)
     expect(await reservations.canReserveSlot(reqId, slotIndex)).to.be.false
   })


### PR DESCRIPTION
Deleting an AddressSet causes corrupted memory. Each address must be removed individually, which is OK to do since there is a maxReservations parameter that keeps this number small.

https://docs.openzeppelin.com/contracts/5.x/api/utils#EnumerableSet