### PR TITLE
fix(integration): fixes hardhat not recognising custom error

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -544,7 +544,11 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
 
   function getActiveSlot(
     SlotId slotId
-  ) public view slotIsNotFree(slotId) returns (ActiveSlot memory) {
+  ) public view returns (ActiveSlot memory) {
+    // Modifier `slotIsNotFree(slotId)` works here, but using the modifier
+    // causes hardhat to return an error "reverted with an unrecognized custom
+    // error (return data: 0x8b41ec7f)".
+    if (_slots[slotId].state == SlotState.Free) revert Marketplace_SlotIsFree();
     Slot storage slot = _slots[slotId];
     ActiveSlot memory activeSlot;
     activeSlot.request = _requests[slot.requestId];


### PR DESCRIPTION
Hardhat has a known issue where custom error selectors are not able to be parsed from the stack trace when there is a revert inside of a modifier. Instead, reverting inline in the function does have present have the same issue in hardhat. 

This is a workaround for an issue in hardhat which is not the best reason to create a patch, however, we need to move forward with work in codex, and this is blocking us.