### PR TITLE
build: docker uses npm ci

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN if [ $(uname -m) = "aarch64" ] ; then \
 WORKDIR ${APP_HOME}
 COPY --chown=${APP_USER}:${APP_USER} . .
 
-RUN npm install
+RUN npm ci
 
 
 # Create

--- a/docker/deploy.Dockerfile
+++ b/docker/deploy.Dockerfile
@@ -23,7 +23,7 @@ RUN if [ $(uname -m) = "aarch64" ] ; then \
 WORKDIR ${APP_HOME}
 COPY --chown=${APP_USER}:${APP_USER} . .
 
-RUN npm install
+RUN npm ci
 
 
 # Create


### PR DESCRIPTION
We should use `npm ci` over `npm install` as `ci` uses lock file for installing deps, while `install` can bump the deps versions.