### PR TITLE
fix: use trySafeTransferFrom instead of transferFrom

### DIFF
--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "./Configuration.sol";
@@ -45,6 +46,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
   using EnumerableSet for EnumerableSet.AddressSet;
   using Requests for Request;
   using AskHelpers for Ask;
+  using SafeERC20 for IERC20;
 
   IERC20 private immutable _token;
   MarketplaceConfig private _config;
@@ -687,7 +689,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
 
   function _transferFrom(address sender, uint256 amount) internal {
     address receiver = address(this);
-    if (!_token.transferFrom(sender, receiver, amount))
+    if (!_token.trySafeTransferFrom(sender, receiver, amount))
       revert Marketplace_TransferFailed();
   }
 

--- a/contracts/Marketplace.sol
+++ b/contracts/Marketplace.sol
@@ -360,7 +360,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
       _config.collateral.validatorRewardPercentage) / 100;
     _marketplaceTotals.sent += validatorRewardAmount;
 
-    if (!_token.transfer(msg.sender, validatorRewardAmount)) {
+    if (!_token.trySafeTransfer(msg.sender, validatorRewardAmount)) {
       revert Marketplace_TransferFailed();
     }
 
@@ -428,11 +428,11 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     uint256 collateralAmount = slot.currentCollateral;
     _marketplaceTotals.sent += (payoutAmount + collateralAmount);
     slot.state = SlotState.Paid;
-    if (!_token.transfer(rewardRecipient, payoutAmount)) {
+    if (!_token.trySafeTransfer(rewardRecipient, payoutAmount)) {
       revert Marketplace_TransferFailed();
     }
 
-    if (!_token.transfer(collateralRecipient, collateralAmount)) {
+    if (!_token.trySafeTransfer(collateralRecipient, collateralAmount)) {
       revert Marketplace_TransferFailed();
     }
   }
@@ -463,11 +463,11 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     uint256 collateralAmount = slot.currentCollateral;
     _marketplaceTotals.sent += (payoutAmount + collateralAmount);
     slot.state = SlotState.Paid;
-    if (!_token.transfer(rewardRecipient, payoutAmount)) {
+    if (!_token.trySafeTransfer(rewardRecipient, payoutAmount)) {
       revert Marketplace_TransferFailed();
     }
 
-    if (!_token.transfer(collateralRecipient, collateralAmount)) {
+    if (!_token.trySafeTransfer(collateralRecipient, collateralAmount)) {
       revert Marketplace_TransferFailed();
     }
   }
@@ -536,7 +536,7 @@ contract Marketplace is SlotReservations, Proofs, StateRetrieval, Endian {
     uint256 amount = context.fundsToReturnToClient;
     _marketplaceTotals.sent += amount;
 
-    if (!_token.transfer(withdrawRecipient, amount)) {
+    if (!_token.trySafeTransfer(withdrawRecipient, amount)) {
       revert Marketplace_TransferFailed();
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "hardhat-deploy-ethers": "^0.3.0-beta.13",
         "prettier": "^2.8.2",
         "prettier-plugin-solidity": "^1.4.2",
-        "solhint": "^5.0.5"
+        "solhint": "^5.1.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -21593,12 +21593,13 @@
       }
     },
     "node_modules/solhint": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/solhint/-/solhint-5.0.5.tgz",
-      "integrity": "sha512-WrnG6T+/UduuzSWsSOAbfq1ywLUDwNea3Gd5hg6PS+pLUm8lz2ECNr0beX609clBxmDeZ3676AiA9nPDljmbJQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-5.1.0.tgz",
+      "integrity": "sha512-KWg4gnOnznxHXzH0fUvnhnxnk+1R50GiPChcPeQgA7SKQTSF1LLIEh8R1qbkCEn/fFzz4CfJs+Gh7Rl9uhHy+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@solidity-parser/parser": "^0.19.0",
+        "@solidity-parser/parser": "^0.20.0",
         "ajv": "^6.12.6",
         "antlr4": "^4.13.1-patch-1",
         "ast-parents": "^0.0.1",
@@ -21623,6 +21624,13 @@
       "optionalDependencies": {
         "prettier": "^2.8.3"
       }
+    },
+    "node_modules/solhint/node_modules/@solidity-parser/parser": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.20.1.tgz",
+      "integrity": "sha512-58I2sRpzaQUN+jJmWbHfbWf9AKfzqCI8JAdFB0vbyY+u8tBRcuTt9LxzasvR0LGQpcRv97eyV7l61FQ3Ib7zVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/solhint/node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -36831,12 +36839,12 @@
       }
     },
     "solhint": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/solhint/-/solhint-5.0.5.tgz",
-      "integrity": "sha512-WrnG6T+/UduuzSWsSOAbfq1ywLUDwNea3Gd5hg6PS+pLUm8lz2ECNr0beX609clBxmDeZ3676AiA9nPDljmbJQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-5.1.0.tgz",
+      "integrity": "sha512-KWg4gnOnznxHXzH0fUvnhnxnk+1R50GiPChcPeQgA7SKQTSF1LLIEh8R1qbkCEn/fFzz4CfJs+Gh7Rl9uhHy+g==",
       "dev": true,
       "requires": {
-        "@solidity-parser/parser": "^0.19.0",
+        "@solidity-parser/parser": "^0.20.0",
         "ajv": "^6.12.6",
         "antlr4": "^4.13.1-patch-1",
         "ast-parents": "^0.0.1",
@@ -36857,6 +36865,12 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "@solidity-parser/parser": {
+          "version": "0.20.1",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.20.1.tgz",
+          "integrity": "sha512-58I2sRpzaQUN+jJmWbHfbWf9AKfzqCI8JAdFB0vbyY+u8tBRcuTt9LxzasvR0LGQpcRv97eyV7l61FQ3Ib7zVw==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "hardhat-deploy-ethers": "^0.3.0-beta.13",
     "prettier": "^2.8.2",
     "prettier-plugin-solidity": "^1.4.2",
-    "solhint": "^5.0.5"
+    "solhint": "^5.1.0"
   }
 }

--- a/test/Marketplace.test.js
+++ b/test/Marketplace.test.js
@@ -215,7 +215,7 @@ describe("Marketplace", function () {
       let insufficient = maxPrice(request) - 1
       await token.approve(marketplace.address, insufficient)
       await expect(marketplace.requestStorage(request)).to.be.revertedWith(
-        "ERC20InsufficientAllowance"
+        "Marketplace_TransferFailed"
       )
     })
 
@@ -456,7 +456,7 @@ describe("Marketplace", function () {
       await marketplace.reserveSlot(slot.request, slot.index)
       await expect(
         marketplace.fillSlot(slot.request, slot.index, proof)
-      ).to.be.revertedWith("ERC20InsufficientAllowance")
+      ).to.be.revertedWith("Marketplace_TransferFailed")
     })
 
     it("collects only requested collateral and not more", async function () {


### PR DESCRIPTION
When using `transferFrom`, the custom error `ERC20InsufficientAllowance` may be raised. This is potentially problematic, because I didn't find this error declared like other custom errors in the Marketplace, meaning that the error would not be recognized if it is raised (if I understand correctly).

Additionally, [we are checking that the transferFrom returns false](https://github.com/codex-storage/codex-contracts-eth/blob/08e91c2443693d2f083adaa9a70baedbbbcba10a/contracts/Marketplace.sol#L690-L691) in order to determine if the operation succeeded or not, [as it is defined in the spec](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5c4b75a9cdda99af901b8c153d0d1e8a90b0139a/contracts/token/ERC20/IERC20.sol#L54-L67) but the [implementation is different](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/5c4b75a9cdda99af901b8c153d0d1e8a90b0139a/contracts/token/ERC20/ERC20.sol#L158-L167) and `false` is never returned as mentioned in [this issue](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/4777#issuecomment-1869719904).

This PR replaces `transferFrom` by `trySafeTransferFrom` to handle the potential errors and returns `Marketplace_TransferFailed` if something went wrong.