### PR TITLE
chore: deploy smart contracts for Devnet on Status L2 Tetsnet

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -33,7 +33,13 @@ module.exports = {
       url: `${process.env.DISTTEST_NETWORK_URL}`,
     },
     codex_devnet: {
-      url: `${process.env.CODEX_DEVNET_URL}`,
+      url: process.env.CODEX_DEVNET_URL
+        ? `${process.env.CODEX_DEVNET_URL}`
+        : `https://public.sepolia.rpc.status.network`,
+      chainId: 1660990954,
+      accounts: process.env.CODEX_DEVNET_PRIVATE_KEY
+        ? [process.env.CODEX_DEVNET_PRIVATE_KEY]
+        : [],
     },
     codex_testnet: {
       url: `${process.env.CODEX_TESTNET_URL}`,

--- a/ignition/deployments/codex_devnet/deployed_addresses.json
+++ b/ignition/deployments/codex_devnet/deployed_addresses.json
@@ -1,0 +1,6 @@
+{
+  "Token#TestToken": "0xccbb4947f53f7ddf05f0E4A686E6927D17e13e66",
+  "Verifier#Groth16Verifier": "0x9837660dAAA1Ae9BbD45A8AeE28442618B914653",
+  "Verifier#TestVerifier": "0xE6f3B9a0200637B39C327c06f78986fe3e6D86fF",
+  "Marketplace#Marketplace": "0xAB35d6870a2C7234802c070bbb69D921E5d7b7cf"
+}


### PR DESCRIPTION
PR deploys smart contracts for Codex Devnet on Status L2 Tesnet, same as we are planning to use for Codex Testnet.

```shell
npm run deploy -- --network codex_devnet
```

As a result a folder `ignition/deployments/chain-1660990954` was created and then manually renamed into the `ignition/deployments/codex_devnet`

On next deployment, we have to pass on more arg at deployment
```shell
npm run deploy -- --network codex_devnet --deployment-id codex_devnet
```

And a note about network name - `codex_devnet`. We left it as is and later could consider to rename it to something like `devnet_status_testnet`.

<details><summary><code>deployment logs</code></summary>

```js
> deploy
> hardhat ignition deploy ignition/modules/marketplace.js --network codex_devnet

✔ Confirm deploy to network codex_devnet (1660990954)? … yes
Hardhat Ignition 🚀

Deploying [ Marketplace ]

Batch #1
  Executed Token#TestToken
  Executed Verifier#Groth16Verifier
  Executed Verifier#TestVerifier

Batch #2
  Executed Marketplace#Marketplace

[ Marketplace ] successfully deployed 🚀

Deployed Addresses

Token#TestToken - 0xccbb4947f53f7ddf05f0E4A686E6927D17e13e66
Verifier#Groth16Verifier - 0x9837660dAAA1Ae9BbD45A8AeE28442618B914653
Verifier#TestVerifier - 0xE6f3B9a0200637B39C327c06f78986fe3e6D86fF
Marketplace#Marketplace - 0xAB35d6870a2C7234802c070bbb69D921E5d7b7cf
```
</details>

[Token#TestToken.json](https://github.com/user-attachments/files/20880907/Token.TestToken.json) is attached to the issue as it is required by Discordbot.


Part of https://github.com/codex-storage/infra-codex/issues/326.