### PR TITLE
ci: add a way to pass contracts repository ref

### DIFF
--- a/.github/workflows/devnet-contracts.yml
+++ b/.github/workflows/devnet-contracts.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: https://public.sepolia.rpc.status.network
         type: string
+      contracts_ref:
+        description: "Contracts ref: blank = current branch"
+        required: false
+        type: string
+        default: ''
 
 
 env:
@@ -35,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.contracts_ref }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This is a quick followup of the https://github.com/codex-storage/codex-contracts-eth/pull/259 and it adds a way to pass contracts repository ref, which is a commit id.

In that way, we should be able to have a pass-through deployment from a nim-codex repository and required changes will be added as a part of the https://github.com/codex-storage/nim-codex/pull/1302.

**Manual deployment**
- Leave _Contracts ref_ field blank to checkout a current branch
   <details><summary><code>screenshot</code></summary>

   <img width="335" height="434" alt="Screenshot 2025-07-23 at 17 22 39" src="https://github.com/user-attachments/assets/b8d5d6fc-f5b5-4f28-a9d3-09c2cb0a933b" />
   </details>

**Auto deployment**
- Workflow in nim-codex repository will get a `codex-contracts-eth` submodule commit id
- Will call this workflow and will pass commit id to deploy a proper contract version 